### PR TITLE
infeasibility check, state_updown no upper limit

### DIFF
--- a/.spinetoolbox/specifications/Exporter/results_to_excel.json
+++ b/.spinetoolbox/specifications/Exporter/results_to_excel.json
@@ -774,7 +774,7 @@
                 {
                     "map_type": "ParameterDefinition",
                     "position": "hidden",
-                    "filter_re": "^state$"
+                    "filter_re": "^state_t$"
                 },
                 {
                     "map_type": "ParameterValueList",
@@ -915,8 +915,7 @@
                 },
                 {
                     "map_type": "ObjectClass",
-                    "position": "hidden",
-                    "filter_re": "^process$"
+                    "position": "hidden"
                 },
                 {
                     "map_type": "ParameterDefinition",

--- a/flexModel3.mod
+++ b/flexModel3.mod
@@ -3379,17 +3379,16 @@ printf 'Write node results for time...\n';
 param fn_node__dt symbolic := "output/node__period__t.csv";
 for {i in 1..1 : p_model['solveFirst']}
   { printf 'node,solve,period,time,inflow,"from units","from connections","to units","to connections",' > fn_node__dt;
-    printf '"state","state change","self discharge","upward slack","downward slack"\n' >> fn_node__dt; }  # Print the header on the first solve
+    printf '"state change","self discharge","upward slack","downward slack"\n' >> fn_node__dt; }  # Print the header on the first solve
 for {n in node, s in solve_current, (d, t) in dt : d in period_realized}
   {
-    printf '%s,%s,%s,%s,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g\n'
+    printf '%s,%s,%s,%s,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g\n'
 		, n, s, d, t
         , (if (n, 'no_inflow') not in node__inflow_method then pdtNodeInflow[n, d, t])
 	    , sum{(p, source, n) in process_source_sink_alwaysProcess : p in process_unit} r_process_source_sink_flow_dt[p, source, n, d, t]
 	    , sum{(p, source, n) in process_source_sink_alwaysProcess : p in process_connection} r_process_source_sink_flow_dt[p, source, n, d, t]
   	    , sum{(p, n, sink) in process_source_sink_alwaysProcess : p in process_unit} -r_process_source_sink_flow_dt[p, n, sink, d, t]
   	    , sum{(p, n, sink) in process_source_sink_alwaysProcess : p in process_connection} -r_process_source_sink_flow_dt[p, n, sink, d, t]
-      , (if n in nodeState then v_state[n, d, t].val * p_entity_unitsize[n] else 0)
 	    , (if n in nodeState then r_nodeState_change_dt[n, d, t] else 0)
         , (if n in nodeSelfDischarge then r_selfDischargeLoss_dt[n, d, t] else 0)
 	    , (if n in nodeBalance then vq_state_up[n, d, t].val * pdtNodeInflow_for_scaling[n, d, t] else 0)

--- a/flexModel3.mod
+++ b/flexModel3.mod
@@ -1559,6 +1559,12 @@ s.t. profile_flow_upper_limit {(p, source, sink, f, 'upper_limit') in process__s
         + sum {(p, d_invest, d) in edd_invest} v_invest[p, d_invest] * p_entity_unitsize[p]
         - sum {(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d_divest] * p_entity_unitsize[p]
 	  )
+    /(if (p, 'min_load_efficiency') in process__ct_method then ptProcess_slope[p, t] else 1 / ptProcess[p, 'efficiency', t])
+      + (if (p, 'min_load_efficiency') in process__ct_method then 
+			  ( + (if p in process_online_linear then v_online_linear[p, d, t]) 
+			  + (if p in process_online_integer then v_online_integer[p, d, t])
+			  )
+      * ptProcess_section[p, t] * p_entity_unitsize[p])
 ;
 
 s.t. profile_flow_lower_limit {(p, source, sink, f, 'lower_limit') in process__source__sink__profile__profile_method, (d, t) in dt} :
@@ -1575,6 +1581,12 @@ s.t. profile_flow_lower_limit {(p, source, sink, f, 'lower_limit') in process__s
         + sum {(p, d_invest, d) in edd_invest} v_invest[p, d_invest] * p_entity_unitsize[p]
         - sum {(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d_divest] * p_entity_unitsize[p]
 	  )
+    /(if (p, 'min_load_efficiency') in process__ct_method then ptProcess_slope[p, t] else 1 / ptProcess[p, 'efficiency', t])
+      + (if (p, 'min_load_efficiency') in process__ct_method then 
+			  ( + (if p in process_online_linear then v_online_linear[p, d, t]) 
+			  + (if p in process_online_integer then v_online_integer[p, d, t])
+			  )
+      * ptProcess_section[p, t] * p_entity_unitsize[p])
 ;
 
 s.t. profile_flow_fixed {(p, source, sink, f, 'fixed') in process__source__sink__profile__profile_method, (d, t) in dt} :
@@ -1590,6 +1602,12 @@ s.t. profile_flow_fixed {(p, source, sink, f, 'fixed') in process__source__sink_
         + sum {(p, d_invest, d) in edd_invest} v_invest[p, d_invest] * p_entity_unitsize[p]
         - sum {(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d_divest] * p_entity_unitsize[p]
 	  )
+    /(if (p, 'min_load_efficiency') in process__ct_method then ptProcess_slope[p, t] else 1 / ptProcess[p, 'efficiency', t])
+      + (if (p, 'min_load_efficiency') in process__ct_method then 
+			  ( + (if p in process_online_linear then v_online_linear[p, d, t]) 
+			  + (if p in process_online_integer then v_online_integer[p, d, t])
+			  )
+      * ptProcess_section[p, t] * p_entity_unitsize[p])
 ;
 
 s.t. profile_state_upper_limit {(n, f, 'upper_limit') in node__profile__profile_method, (d, t) in dt} :

--- a/flexModel3.mod
+++ b/flexModel3.mod
@@ -1559,12 +1559,13 @@ s.t. profile_flow_upper_limit {(p, source, sink, f, 'upper_limit') in process__s
         + sum {(p, d_invest, d) in edd_invest} v_invest[p, d_invest] * p_entity_unitsize[p]
         - sum {(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d_divest] * p_entity_unitsize[p]
 	  )
-    /(if (p, 'min_load_efficiency') in process__ct_method then ptProcess_slope[p, t] else 1 / ptProcess[p, 'efficiency', t])
-      + (if (p, 'min_load_efficiency') in process__ct_method then 
-			  ( + (if p in process_online_linear then v_online_linear[p, d, t]) 
-			  + (if p in process_online_integer then v_online_integer[p, d, t])
-			  )
-      * ptProcess_section[p, t] * p_entity_unitsize[p])
+      / (if (p, 'min_load_efficiency') in process__ct_method then ptProcess_slope[p, t] else 1 / ptProcess[p, 'efficiency', t])
+  + ( if (p, 'min_load_efficiency') in process__ct_method then 
+	    ( + (if p in process_online_linear then v_online_linear[p, d, t]) 
+		  + (if p in process_online_integer then v_online_integer[p, d, t])
+		)
+        * ptProcess_section[p, t] * p_entity_unitsize[p]
+	)
 ;
 
 s.t. profile_flow_lower_limit {(p, source, sink, f, 'lower_limit') in process__source__sink__profile__profile_method, (d, t) in dt} :
@@ -1581,12 +1582,13 @@ s.t. profile_flow_lower_limit {(p, source, sink, f, 'lower_limit') in process__s
         + sum {(p, d_invest, d) in edd_invest} v_invest[p, d_invest] * p_entity_unitsize[p]
         - sum {(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d_divest] * p_entity_unitsize[p]
 	  )
-    /(if (p, 'min_load_efficiency') in process__ct_method then ptProcess_slope[p, t] else 1 / ptProcess[p, 'efficiency', t])
-      + (if (p, 'min_load_efficiency') in process__ct_method then 
-			  ( + (if p in process_online_linear then v_online_linear[p, d, t]) 
-			  + (if p in process_online_integer then v_online_integer[p, d, t])
-			  )
-      * ptProcess_section[p, t] * p_entity_unitsize[p])
+      / (if (p, 'min_load_efficiency') in process__ct_method then ptProcess_slope[p, t] else 1 / ptProcess[p, 'efficiency', t])
+  + ( if (p, 'min_load_efficiency') in process__ct_method then 
+		( + (if p in process_online_linear then v_online_linear[p, d, t]) 
+		  + (if p in process_online_integer then v_online_integer[p, d, t])
+		)
+        * ptProcess_section[p, t] * p_entity_unitsize[p]
+	)
 ;
 
 s.t. profile_flow_fixed {(p, source, sink, f, 'fixed') in process__source__sink__profile__profile_method, (d, t) in dt} :

--- a/flexModel3.mod
+++ b/flexModel3.mod
@@ -1191,8 +1191,8 @@ var v_startup_integer {p in process_online_integer, (d, t) in dt} >=0, <= p_enti
 var v_shutdown_integer {p in process_online_integer, (d, t) in dt} >=0, <= p_entity_max_units[p, d];
 var v_invest {(e, d) in ed_invest} >= 0, <= p_entity_max_units[e, d];
 var v_divest {(e, d) in ed_divest} >= 0, <= p_entity_max_units[e, d];
-var vq_state_up {n in nodeBalance, (d, t) in dt} >= 0, <= 1;
-var vq_state_down {n in nodeBalance, (d, t) in dt} >= 0, <= 1;
+var vq_state_up {n in nodeBalance, (d, t) in dt} >= 0;
+var vq_state_down {n in nodeBalance, (d, t) in dt} >= 0;
 var vq_reserve {(r, ud, ng) in reserve__upDown__group, (d, t) in dt} >= 0, <= 1;
 var vq_inertia {g in groupInertia, (d, t) in dt} >= 0, <= 1;
 var vq_non_synchronous {g in groupNonSync, (d, t) in dt} >= 0;

--- a/flextoolrunner.py
+++ b/flextoolrunner.py
@@ -420,9 +420,9 @@ class FlexToolRunner:
                 print("HiGHS solved the problem\n")
                 
                 #checking if solution is infeasible. This is quite clumsy way of doing this, but the solvers do not give infeasible exitstatus
-                with open('flexModel3.sol','r') as inf_file:
+                with open('HiGHS.log','r') as inf_file:
                     inf_content = inf_file.read() 
-                    if 'INFEASIBLE' in inf_content:
+                    if 'Infeasible' in inf_content:
                         logging.error(f"The model is infeasible. Check the constraints.")
                         exit(1)
             


### PR DESCRIPTION
v_state_up and v_state_down had <1 constraint. This means that the energy created could only be at maximum the inflow. However the supply surplus can be higher than this if upper_limit constraints are not used in profiles, resulting in a infeasible problem. Is there a reason for this constraint?
Infeasible error message fixed as the information is not always in the result file. It is sometimes an empty file. The information is still in the HiGHS.log.
In node__period_t column name to "state change" to match the data. 
r_nodeState_change_dt to match the same timesteps as the other flows.
Fixes in the to_excel specification.
Efficiency in units with profile didn't do anything. This is now added to the profile flow constraints.