### PR TITLE
result_update, reserve and multi_invest_2d_map fixing

### DIFF
--- a/.spinetoolbox/specifications/Exporter/export_flextool3_csv.json
+++ b/.spinetoolbox/specifications/Exporter/export_flextool3_csv.json
@@ -913,7 +913,7 @@
             "use_fixed_table_name": true
         },
         "process__reserve__upDown__node": {
-            "type": "entity_parameter_values",
+            "type": "entities",
             "mapping": [
                 {
                     "map_type": "FixedValue",
@@ -942,16 +942,6 @@
                     "position": "hidden"
                 },
                 {
-                    "map_type": "ParameterDefinition",
-                    "position": "hidden",
-                    "filter_re": "is_active"
-                },
-                {
-                    "map_type": "ParameterValueList",
-                    "position": "hidden",
-                    "ignorable": true
-                },
-                {
                     "map_type": "Entity",
                     "position": "hidden"
                 },
@@ -974,19 +964,6 @@
                     "map_type": "Element",
                     "position": 3,
                     "header": "node"
-                },
-                {
-                    "map_type": "Alternative",
-                    "position": "hidden"
-                },
-                {
-                    "map_type": "ParameterValueType",
-                    "position": "hidden"
-                },
-                {
-                    "map_type": "ParameterValue",
-                    "position": "hidden",
-                    "filter_re": "yes"
                 }
             ],
             "enabled": true,

--- a/flextoolrunner.py
+++ b/flextoolrunner.py
@@ -64,7 +64,7 @@ class FlexToolRunner:
         self.realized_invest_periods = self.get_list_of_tuples('input/solve__realized_invest_period.csv') + self.get_2d_map_periods('input/solve__realized_invest_period_2d_map.csv')
         self.fix_storage_periods = self.get_list_of_tuples('input/solve__fix_storage_period.csv') + self.get_2d_map_periods('input/solve__fix_storage_period_2d_map.csv')
         #self.write_full_timelines(self.timelines, 'steps.csv')
-    
+
     def get_2d_timeblocks_used_by_solves(self):
 
         with open('input/timeblocks_in_use_2d.csv', 'r') as blk:
@@ -93,6 +93,18 @@ class FlexToolRunner:
                     new_name = datain[0]+"_"+datain[1]
                     self.duplicate_solve(datain[0],new_name)
                     period_list.append((new_name,datain[2]))
+                    new_period_timeblockset_list = []
+                    for solve, period__timeblockset_list in list(self.timeblocks_used_by_solves.items()):
+                        if solve == datain[0]:
+                            for period__timeblockset in period__timeblockset_list:
+                                if period__timeblockset[0] == datain[2]:
+                                    new_period_timeblockset_list.append(period__timeblockset)
+                    if new_name not in self.timeblocks_used_by_solves.keys():
+                        self.timeblocks_used_by_solves[new_name] = new_period_timeblockset_list
+                    else:
+                        for item in new_period_timeblockset_list:
+                            if item not in self.timeblocks_used_by_solves[new_name]:
+                                self.timeblocks_used_by_solves[new_name].append(item)
                 except StopIteration:
                     break
         return period_list

--- a/version/flextool_template_results_master.json
+++ b/version/flextool_template_results_master.json
@@ -191,7 +191,7 @@
             "inertia_unit_node_t",
             null,
             null,
-            "[MWs] the amount of inertia in the flows between the units and the nodes in the group"
+            "[MWs] the amount of inertia in the flows between the units and the nodes in the group."
         ],
         [
             "group",


### PR DESCRIPTION
- update_flextool.py would crash if nothing to commit to Results.sqlite, fixed this by adding SpineDBAPIError check. Additionally, a small change to the results_template_master.json, because update_flextool.py updates itself with a 1 lag and this prevents the 'nothing to commit' error for the next update. 
- process_reserve_upDown_node was still using 'is_active' parameter
- Creating multiple invest solves with 2d maps was broken