### PR TITLE
Stochastics, timeline aggregation, excel import scenario fixes

### DIFF
--- a/.spinetoolbox/specifications/Importer/flextool3_excel_input.json
+++ b/.spinetoolbox/specifications/Importer/flextool3_excel_input.json
@@ -8,7 +8,7 @@
                     "Solve settings": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "skip_columns": [
@@ -24,11 +24,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -54,7 +54,7 @@
                     "Solve sequence": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "model",
                                 "skip_columns": [
@@ -63,12 +63,12 @@
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "from_template"
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -109,7 +109,7 @@
                     "Solver arguments": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "skip_columns": [
@@ -123,11 +123,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -170,16 +170,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "timeblockSet"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -220,16 +220,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "timeline"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -257,36 +257,36 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "timeblockSet__timeline"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "header",
                                 "value": 0
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "header",
                                 "value": 1
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 0,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -298,16 +298,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -335,16 +335,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -386,7 +386,7 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node",
                                 "skip_columns": [
@@ -394,11 +394,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": -3
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -440,16 +440,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "commodity"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -477,7 +477,7 @@
                     "data": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection",
                                 "skip_columns": [
@@ -486,11 +486,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -516,45 +516,45 @@
                     "relationships": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection__node__node",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 3
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -566,16 +566,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -617,7 +617,7 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection",
                                 "skip_columns": [
@@ -625,11 +625,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": -3
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -671,7 +671,7 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "profile",
                                 "skip_columns": [
@@ -679,11 +679,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": -2
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -726,16 +726,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -763,16 +763,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -814,7 +814,7 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit",
                                 "skip_columns": [
@@ -822,11 +822,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": -3
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -868,17 +868,17 @@
                     "Mapping 2": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "constraint",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -905,17 +905,17 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "constraint",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -942,17 +942,17 @@
                     "Mapping 3": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "constraint",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -981,16 +981,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1018,35 +1018,35 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "group__connection"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 0
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -1058,44 +1058,44 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "group__connection__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 0
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -1107,35 +1107,35 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "group__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 0
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -1147,35 +1147,35 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "group__unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 0
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -1187,44 +1187,44 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "group__unit__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 0
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -1236,57 +1236,57 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "reserve__upDown__connection__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "reserve"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "upDown"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 3,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 4,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1314,47 +1314,47 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "reserve__upDown__group"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "reserve"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "upDown"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 3,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1382,7 +1382,7 @@
                     "unit_sources": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "reserve__upDown__group",
                                 "skip_columns": [
@@ -1390,39 +1390,39 @@
                                 ]
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "reserve"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "upDown"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -2
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -3
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -4
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden",
                                 "filter_re": "^source$"
                             },
@@ -1463,7 +1463,7 @@
                     "unit_sinks": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "reserve__upDown__group",
                                 "skip_columns": [
@@ -1471,39 +1471,39 @@
                                 ]
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "reserve"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "upDown"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -2
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -3
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -4
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1545,57 +1545,57 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "reserve__upDown__unit__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "reserve"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "upDown"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 3,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 4,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1623,16 +1623,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "commodity"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1674,35 +1674,35 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "commodity__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "commodity"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 0
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -1714,17 +1714,17 @@
                     "realized_periods": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1766,7 +1766,7 @@
                     "solve_data": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "skip_columns": [
@@ -1775,11 +1775,11 @@
                                 ]
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1819,17 +1819,17 @@
                     "invest_periods": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1871,17 +1871,17 @@
                     "realized_invest_periods": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1923,17 +1923,17 @@
                     "fix_storage_periods": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -1977,16 +1977,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "timeline"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2028,16 +2028,16 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "group"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2079,7 +2079,7 @@
                     "sources": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit__inputNode",
                                 "skip_columns": [
@@ -2087,30 +2087,30 @@
                                 ]
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": 3,
                                 "filter_re": "^input$"
                             },
@@ -2137,7 +2137,7 @@
                     "sinks": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit__outputNode",
                                 "skip_columns": [
@@ -2145,30 +2145,30 @@
                                 ]
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": 3,
                                 "filter_re": "^output$"
                             },
@@ -2197,7 +2197,7 @@
                     "unit_sources": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit__inputNode",
                                 "skip_columns": [
@@ -2205,30 +2205,30 @@
                                 ]
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -3
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -4
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": -5,
                                 "filter_re": "^input$"
                             },
@@ -2269,7 +2269,7 @@
                     "unit_sinks": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit__outputNode",
                                 "skip_columns": [
@@ -2277,30 +2277,30 @@
                                 ]
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -3
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": -4
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": -5,
                                 "filter_re": "^output$"
                             },
@@ -2343,35 +2343,35 @@
                     "sources": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit__inputNode"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": 3,
                                 "filter_re": "^input$"
                             },
@@ -2412,35 +2412,35 @@
                     "sinks": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit__outputNode"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": 3,
                                 "filter_re": "^output$"
                             },
@@ -2483,15 +2483,15 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": "hidden"
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -2503,15 +2503,15 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": "hidden"
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             }
                         ]
@@ -2523,35 +2523,35 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node__profile"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "profile"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2579,35 +2579,35 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection__profile"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "profile"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2635,47 +2635,47 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit__node__profile"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "profile"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 3,
-                                "import_objects": true
+                                "import_entities": true
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2708,10 +2708,6 @@
                                 "skip_columns": [
                                     0
                                 ]
-                            },
-                            {
-                                "map_type": "ScenarioAlternative",
-                                "position": -3
                             }
                         ]
                     }
@@ -2727,9 +2723,8 @@
                                 ]
                             },
                             {
-                                "map_type": "ScenarioActiveFlag",
-                                "position": "hidden",
-                                "value": "false"
+                                "map_type": "ScenarioAlternative",
+                                "position": -3
                             }
                         ]
                     }
@@ -2740,35 +2735,35 @@
                     "sources": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2808,35 +2803,35 @@
                     "sinks": {
                         "mapping": [
                             {
-                                "map_type": "RelationshipClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection__node"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "RelationshipClassObjectClass",
+                                "map_type": "Dimension",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Relationship",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "relationship"
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 1
                             },
                             {
-                                "map_type": "RelationshipObject",
+                                "map_type": "Element",
                                 "position": 2
                             },
                             {
-                                "map_type": "RelationshipMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2878,16 +2873,16 @@
                     "sources": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2927,16 +2922,16 @@
                     "sinks": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -2978,16 +2973,16 @@
                     "sources": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -3027,16 +3022,16 @@
                     "sinks": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "unit"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -3078,16 +3073,16 @@
                     "sources": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "node"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -3127,16 +3122,16 @@
                     "sinks": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "connection"
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -3178,17 +3173,17 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "solve",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": 1
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -3216,18 +3211,18 @@
                     "Mapping 1": {
                         "mapping": [
                             {
-                                "map_type": "ObjectClass",
+                                "map_type": "EntityClass",
                                 "position": "hidden",
                                 "value": "model",
                                 "read_start_row": 2
                             },
                             {
-                                "map_type": "Object",
+                                "map_type": "Entity",
                                 "position": "hidden",
                                 "value": "from_template"
                             },
                             {
-                                "map_type": "ObjectMetadata",
+                                "map_type": "EntityMetadata",
                                 "position": "hidden"
                             },
                             {
@@ -3360,7 +3355,9 @@
             "connection_profile_c": {},
             "unit_node_profile_c": {},
             "scenario": {
-                "row": 1
+                "row": 1,
+                "header": false,
+                "column": 0
             },
             "connection_node_constraint_c": {},
             "node_constraint_c": {},

--- a/flexModel3.mod
+++ b/flexModel3.mod
@@ -2205,12 +2205,14 @@ s.t. constraint_greater_than {(c, 'greater_than') in constraint__sense, (d, t) i
 	    - sum{(n, d_divest) in nd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[n, d]
 	  )
 	  * p_node_constraint_capacity_coefficient[n, c]
+    * p_entity_unitsize[n]
 	)
   + sum {(p, c) in process_capacity_constraint : d in period_invest}
     ( ( + sum{(p, d_invest, d) in edd_invest} v_invest[p, d]
 	    - sum{(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d]
 	  )
 	  * p_process_constraint_capacity_coefficient[p, c]
+    * p_entity_unitsize[p]
 	)
   >=
   + p_constraint_constant[c]
@@ -2235,12 +2237,14 @@ s.t. process_constraint_less_than {(c, 'less_than') in constraint__sense, (d, t)
 	    - sum{(n, d_divest) in nd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[n, d]
 	  )
 	  * p_node_constraint_capacity_coefficient[n, c]
+    * p_entity_unitsize[n]
 	)
   + sum {(p, c) in process_capacity_constraint : d in period_invest}
     ( ( + sum{(p, d_invest, d) in edd_invest} v_invest[p, d]
 	    - sum{(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d]
 	  )
 	  * p_process_constraint_capacity_coefficient[p, c]
+    * p_entity_unitsize[p]
 	)
   <=
   + p_constraint_constant[c]
@@ -2265,12 +2269,14 @@ s.t. process_constraint_equal {(c, 'equal') in constraint__sense, (d, t) in dt} 
 	    - sum{(n, d_divest) in nd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[n, d]
 	  )
 	  * p_node_constraint_capacity_coefficient[n, c]
+    * p_entity_unitsize[n]
 	)
   + sum {(p, c) in process_capacity_constraint : d in period_invest}
     ( ( + sum{(p, d_invest, d) in edd_invest} v_invest[p, d]
 	    - sum{(p, d_divest) in pd_divest : p_years_d[d_divest] <= p_years_d[d]} v_divest[p, d]
 	  )
 	  * p_process_constraint_capacity_coefficient[p, c]
+    * p_entity_unitsize[p]
 	)
   =
   + p_constraint_constant[c]

--- a/flexModel3.mod
+++ b/flexModel3.mod
@@ -358,6 +358,7 @@ param p_entity_period_invested_capacity {e in entity, d in period_with_history};
 set groupStochastic dimen 1 within {group};
 set solve_branch__time_branch dimen 2 within {branch_all, time_branch_all};
 param p_branch_weight_input {b in branch} default 1;
+#normalize the branches with the same starting time to add up to 1
 param p_branch_weight {b in branch} := 
 p_branch_weight_input[b] /(sum{(d,b2) in period__branch, (b2, ts) in period__time_first: (b,ts) in period__time_first && (d,b) in period__branch} p_branch_weight_input[b2]);
 
@@ -1696,8 +1697,7 @@ param setup2 := gmtime() - datetime0 - setup1 - w_calc_slope;
 display setup2;
 minimize total_cost:
 ( + sum {(c, n) in commodity_node, (d, t) in dt}
-    + p_branch_weight[d] *
-	( pdCommodity[c, 'price', d]
+    (+ pdCommodity[c, 'price', d]
 	  * (
 		  # Buying a commodity (increases the objective function)
 		  + sum {(p, n, sink) in process_source_sink_noEff } 
@@ -1719,11 +1719,10 @@ minimize total_cost:
 			  + v_flow[p, source, n, d, t] * p_entity_unitsize[p]
 			)  
 		)
-	  * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+	  * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	)
   + sum {(g, c, n, d, t) in gcndt_co2_price} 
-	  + p_branch_weight[d] *
-  ( p_commodity[c, 'co2_content'] * pdGroup[g, 'co2_price', d] 
+    (+ p_commodity[c, 'co2_content'] * pdGroup[g, 'co2_price', d] 
 	  * (
 		  # Paying for CO2 (increases the objective function)
 		  + sum {(p, n, sink) in process_source_sink_noEff } 
@@ -1745,30 +1744,25 @@ minimize total_cost:
 			  + v_flow[p, source, n, d, t] * p_entity_unitsize[p]
 			)  
 	    )		
-	  * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+	  * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	)
-  + sum {(p, d, t) in pdt_online_linear}
-    + p_branch_weight[d] * 
-      ( v_startup_linear[p, d, t] * pdProcess[p, 'startup_cost', d] 
+  + sum {(p, d, t) in pdt_online_linear} 
+      ( + v_startup_linear[p, d, t] * pdProcess[p, 'startup_cost', d] 
 	      * p_entity_unitsize[p] 
-		  * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+		  * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	  )
   + sum {(p, d, t) in pdt_online_integer}
-    + p_branch_weight[d] * 
-      ( v_startup_integer[p, d, t] * pdProcess[p, 'startup_cost', d] 
+      ( + v_startup_integer[p, d, t] * pdProcess[p, 'startup_cost', d] 
 	      * p_entity_unitsize[p] 
-		  * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+		  * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	  )
   + sum {(p, source, sink, d, t) in pssdt_varCost_noEff}
-    + p_branch_weight[d] *
     ( + pdtProcess__source__sink__dt_varCost[p, source, sink, d, t]
 	    * v_flow[p, source, sink, d, t] * p_entity_unitsize[p]
-        * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+        * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	)
   + sum {(p, source, sink, d, t) in pssdt_varCost_eff_unit_source}
-    + p_branch_weight[d] *
-    (  
-      - pdtProcess_source[p, source, 'other_operational_cost', d, t]
+    ( - pdtProcess_source[p, source, 'other_operational_cost', d, t]
 	    *  
 	    ( + v_flow[p, source, sink, d, t] * p_entity_unitsize[p] 
 		    * (if (p, 'min_load_efficiency') in process__ct_method then pdtProcess_slope[p, d, t] else 1 / pdtProcess[p, 'efficiency', d, t])
@@ -1781,45 +1775,41 @@ minimize total_cost:
 			    * p_entity_unitsize[p]
 			)
 		)	  
-        * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+        * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	)
   + sum {(p, source, sink, d, t) in pssdt_varCost_eff_unit_sink}
-    + p_branch_weight[d] *
     ( + pdtProcess_sink[p, sink, 'other_operational_cost', d, t]
 	    * v_flow[p, source, sink, d, t] * p_entity_unitsize[p]
-        * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+        * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	)
   + sum {(p, source, sink, d, t) in pssdt_varCost_eff_connection}
-    + p_branch_weight[d] *
     ( + pdtProcess[p, 'other_operational_cost', d, t]
  	   * v_flow[p, source, sink, d, t] * p_entity_unitsize[p]
-       * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+       * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
 	)
 #  + sum {(p, source, sink, m) in process__source__sink__ramp_method, (d, t) in dt : m in ramp_cost_method}
-#    ( + v_ramp[p, source, sink, d, t] * p_entity_unitsize[p] * pProcess_source_sink[p, source, sink, 'ramp_cost'] ) * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+#    ( + v_ramp[p, source, sink, d, t] * p_entity_unitsize[p] * pProcess_source_sink[p, source, sink, 'ramp_cost'] ) * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d]
   + sum {g in groupInertia, (d, t) in dt} p_branch_weight[d] * vq_inertia[g, d, t] * pdGroup[g, 'inertia_limit', d]
-                                            * pdGroup[g, 'penalty_inertia', d] * step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+                                            * pdGroup[g, 'penalty_inertia', d] * step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d]
   + sum {g in groupNonSync, (d, t) in dt} p_branch_weight[d] * vq_non_synchronous[g, d, t] * group_capacity_for_scaling[g, d]
-                                            * pdGroup[g, 'penalty_non_synchronous', d]  * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+                                            * pdGroup[g, 'penalty_non_synchronous', d]  * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d]
   + sum {n in nodeBalance, (d, t) in dt} p_branch_weight[d] * vq_state_up[n, d, t] * node_capacity_for_scaling[n, d]
-                                            * pdtNode[n, 'penalty_up', d, t]  * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+                                            * pdtNode[n, 'penalty_up', d, t]  * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d]
   + sum {n in nodeBalance, (d, t) in dt} p_branch_weight[d] * vq_state_down[n, d, t] * node_capacity_for_scaling[n, d]
-                                            * pdtNode[n, 'penalty_down', d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+                                            * pdtNode[n, 'penalty_down', d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d]
   + sum {(r, ud, ng) in reserve__upDown__group, (d, t) in dt} p_branch_weight[d] * vq_reserve[r, ud, ng, d, t]  * pdtReserve_upDown_group[r, ud, ng, 'reservation', d, t]
-                                            * p_reserve_upDown_group[r, ud, ng, 'penalty_reserve']  * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+                                            * p_reserve_upDown_group[r, ud, ng, 'penalty_reserve']  * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d]
 
   - sum {n in nodeState, (d, t) in period__time_last : (n, 'use_reference_price') in node__storage_solve_horizon_method && d in period_last}
-    + p_branch_weight[d]
-      * pdNode[n, 'storage_state_reference_price', d]
+    + pdNode[n, 'storage_state_reference_price', d]
         * v_state[n, d, t] * p_entity_unitsize[n]
-		* step_duration[d, t] * p_discount_factor_operations_yearly[d] / period_share_of_year[d]
+		* step_duration[d, t] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] * p_branch_weight[d]
   + sum {e in entity, d in period_in_use}  # This is constant term and will be dropped by the solver. Here for completeness.
-    + p_branch_weight[d]
-      * p_entity_all_existing[e, d]
+    + p_entity_all_existing[e, d]
       * ( + (if e in node then pdNode[e, 'fixed_cost', d] * 1000)
 	      + (if e in process then pdProcess[e, 'fixed_cost', d] * 1000)
 		)
-	  * p_discount_factor_operations_yearly[d]
+	  * p_discount_factor_operations_yearly[d] * p_branch_weight[d]
   + sum {(e, d) in ed_invest} 
     + p_branch_weight[d]
       * v_invest[e, d]
@@ -2914,7 +2904,7 @@ s.t. co2_max_period{g in group_co2_max_period, d in period_in_use} :
             # CO2 removals
             - sum {(p, source, n) in process_source_sink, (d, t) in dt } 
               ( + v_flow[p, source, n, d, t] * p_entity_unitsize[p] * step_duration[d, t] )  
-          ) / period_share_of_year[d]
+          ) / complete_period_share_of_year[d]
     )
   <=
   + pdGroup[g, 'co2_max_period', d]
@@ -3555,31 +3545,31 @@ for {s in solve_current} { printf '\n\n"Solve",%s\n', s >> fn_summary; }
 printf '"Total cost obj. function (M CUR)",%.12g,"Minimized total system cost as ', (total_cost.val / scale_the_objective / 1000000) >> fn_summary;
 printf 'given by the solver (includes all penalty costs)"\n' >> fn_summary;
 printf '"Total cost (calculated) full horizon (M CUR)",%.12g,', sum{d in period_in_use} 
-           ( + r_costOper_and_penalty_d[d] * p_discount_factor_operations_yearly[d] / period_share_of_year[d] 
+           ( + r_costOper_and_penalty_d[d] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] 
 		     + r_costInvest_d[d]
 			 + r_costDivest_d[d]
 		   ) / 1000000 >> fn_summary;
 printf '"Annualized operational, penalty and investment costs"\n' >> fn_summary;
 printf '"Total cost (calculated) realized periods (M CUR)",%.12g\n', sum{d in period_in_use} 
-           ( + r_costOper_and_penalty_d[d] * p_discount_factor_operations_yearly[d] / period_share_of_year[d] 
+           ( + r_costOper_and_penalty_d[d] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] 
 		     + r_costInvest_d[d]
 			 + r_costDivest_d[d]
 		   ) / 1000000 >> fn_summary;
 printf '"Operational costs for realized periods (M CUR)",%.12g\n', sum{d in d_realized_period} 
-           + r_costOper_d[d] * p_discount_factor_operations_yearly[d] / period_share_of_year[d] / 1000000>> fn_summary;
+           + r_costOper_d[d] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] / 1000000>> fn_summary;
 printf '"Investment costs for realized periods (M CUR)",%.12g\n', sum{d in d_realize_invest} 
            + r_costInvest_d[d] / 1000000 >> fn_summary;
 printf '"Retirement costs (negative salvage value) for realized periods (M CUR)",%.12g\n', sum{d in d_realize_invest} 
            + r_costDivest_d[d] / 1000000 >> fn_summary;
 printf '"Fixed costs for existing units (M CUR)",%.12g\n', sum{d in d_realize_invest} r_costExistingFixed_d[d] / 1000000 >> fn_summary;
 printf '"Penalty (slack) costs for realized periods (M CUR)",%.12g\n', sum{d in d_realized_period} 
-           + r_costPenalty_d[d] * p_discount_factor_operations_yearly[d] / period_share_of_year[d] / 1000000 >> fn_summary;
+           + r_costPenalty_d[d] * p_discount_factor_operations_yearly[d] / complete_period_share_of_year[d] / 1000000 >> fn_summary;
 printf '\nPeriod' >> fn_summary;
 for {d in period}
   { printf ',%s', d >> fn_summary; }
 printf '\n"Time in use in years"' >> fn_summary;
 for {d in period}
-  { printf ',%.12g', period_share_of_year[d] >> fn_summary; }
+  { printf ',%.12g', complete_period_share_of_year[d] >> fn_summary; }
 printf '\n"Operational discount factor"' >> fn_summary;
 for {d in period}
   { printf ',%.12g', p_discount_factor_operations_yearly[d] >> fn_summary; }
@@ -4615,7 +4605,7 @@ for {s in solve_current: 'yes' not in exclude_entity_outputs}
     { printf '\n%s,%s,%s', s, d, t >> fn_nodal_prices__dt;
       for {c in solve_current, n in nodeBalance}
       {
-        printf ',%8g', -nodeBalance_eq[c, n, d, t, t_previous, t_previous_within_block, d_previous, t_previous_within_solve].dual / p_discount_factor_operations_yearly[d] * period_share_of_year[d] / scale_the_objective >> fn_nodal_prices__dt;
+        printf ',%8g', -nodeBalance_eq[c, n, d, t, t_previous, t_previous_within_block, d_previous, t_previous_within_solve].dual / p_discount_factor_operations_yearly[d] * complete_period_share_of_year[d] / scale_the_objective >> fn_nodal_prices__dt;
         }
   }}
 


### PR DESCRIPTION
REPLACED period_share_of_year with complete_period_share_of_year for obj_function,  has caused issues with stochastics, inter-period rolling and nodal_price.
Fix timeline aggregation for timeseries without all timesteps (eq. storage_reference_value)
Only aggregate once per roll patch.
Excel import scenario fixed after broken with 0.8
Fixed constraint_capacity to include unitsize

