### PR TITLE
Make usages of DatabaseMapping future proof

### DIFF
--- a/flextool/initialize_database.py
+++ b/flextool/initialize_database.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import argparse
 from spinedb_api import import_data, DatabaseMapping
 from flextool.migrate_database import migrate_database
@@ -16,11 +15,11 @@ def initialize_database(database_name="new_database.sqlite"):
         template = json.load(json_file)
 
 
-    new_db = DatabaseMapping('sqlite:///' + database_name, create = True)
-    (num,log) = import_data(new_db,**template)
-    print(str(num)+" imports made")
-    print("Initialized")
-    new_db.commit_session("Initialized")
+    with DatabaseMapping('sqlite:///' + database_name, create = True) as new_db:
+        (num,log) = import_data(new_db,**template)
+        print(str(num)+" imports made")
+        print("Initialized")
+        new_db.commit_session("Initialized")
 
     migrate_database(database_name)
 

--- a/flextool/migrate_database.py
+++ b/flextool/migrate_database.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 import argparse
 from spinedb_api import import_data, DatabaseMapping, from_database, SpineDBAPIError
 
@@ -11,117 +10,117 @@ def migrate_database(database_path):
         print("No sqlite file at " + database_path)
         exit(-1)
 
-    db = DatabaseMapping('sqlite:///' + database_path, create = False, upgrade = True)
-    sq= db.object_parameter_definition_sq
-    settings_parameter = db.query(sq).filter(sq.c.object_class_name == "model").filter(sq.c.parameter_name == "version").one_or_none()
-    if settings_parameter is None:
-        #if no version assume version 0
-        print("No version found. Assuming version 0, if older, migration might not work")
-        version = 0
-    else:
-        version = from_database(settings_parameter.default_value, settings_parameter.default_type)
-
-    next_version = int(version) + 1
-    new_version = 22
-
-    while next_version <= new_version:
-        if next_version == 0:
-            add_version(db)
-        elif next_version == 1:
-            add_new_parameters(db, './version/flextool_template_v2.json')
-        elif next_version == 2:
-            add_new_parameters(db, './version/flextool_template_rolling_window.json')
-        elif next_version == 3:
-            add_new_parameters(db, './version/flextool_template_lifetime_method.json')
-        elif next_version == 4:
-            add_new_parameters(db, './version/flextool_template_drop_down.json')
-        elif next_version == 5:
-            add_new_parameters(db, './version/flextool_template_optional_outputs.json')
-        elif next_version == 6:
-            add_new_parameters(db, './version/flextool_template_default_value.json')
-        elif next_version == 7:
-            add_new_parameters(db, './version/flextool_template_rolling_start_remove.json')
-        elif next_version == 8:
-            add_new_parameters(db, './version/flextool_template_output_node_flows.json')
-        elif next_version == 9:
-            add_new_parameters(db, './version/flextool_template_constant_default.json')
-        elif next_version == 10:
-            add_new_parameters(db, './version/flextool_template_storage_binding_defaults.json')
-        elif next_version == 11:
-            change_optional_output_type(db,'./version/flextool_template_default_optional_output.json')
-        elif next_version == 12:
-            new_parameters = [["group", "output_aggregate_flows", None, "output_node_flows", "Used with group_unit_node or group_connection_node to combine the flows when producing the output_node_flows of a node group."],
-                              ["group", "output_node_flows", None, "output_node_flows" ,"Creates the timewise flow output for this node group (group_flow_t)"]]
-            add_parameters_manual(db,new_parameters)
-            remove_parameters_manual(db,[["solve","rolling_start_time"]])
-        elif next_version == 13:
-            new_value_list = [["load_share_type","equal"],["load_share_type","inflow_weighted"],["load_share_type","no"]]
-            new_parameters = [["group", "share_loss_of_load", "no", "load_share_type", "Force the upward slack of the nodes in this group to be equal or inflow (demand) weighted"]]
-            #value list needs to be added first
-            add_value_list_manual(db,new_value_list)
-            add_parameters_manual(db,new_parameters)
-            remove_parameters_manual(db,[["node","storate_state_end"]])
-        elif next_version == 14:
-            new_parameters = [["model","exclude_entity_outputs", "yes", "optional_output", "Excludes results on node, unit and connection level, but preserves group level results"]]
-            remove_parameters_manual(db, [["model","results"]])
-            add_parameters_manual(db, new_parameters)
-        elif next_version == 15:
-            remove_parameters_manual(db,[["unit", "invest_forced"], ["unit", "retire_forced"], ["connection", "invest_forced"], ["connection", "retire_forced"],
-                                         ["node", "invest_forced"], ["node", "retire_forced"]])
-            add_parameters_manual(db, [["group", "co2_max_period", "no_method", "co2_methods", "[tCO2] Annualized maximum limit for emitted CO2 in each period."]])
-        elif next_version == 16: 
-            add_parameters_manual(db, [["group", "co2_max_period", None, None, "[tCO2] Annualized maximum limit for emitted CO2 in each period."]])
-        elif next_version == 17:
-            add_value_list_manual(db,[["yes_no", "yes"], ["yes_no", "no"]])
-            new_parameters = [["solve", "stochastic_branches", None, None, "[4d-Map], Sets branches included in the solve. [Period, branch, start_time (time_step), realized (yes/no), weight (number)]. Only one of the branches should be realized for each start_time"],
-                              ["group", "include_stochastics", "no", "yes_no", "Includes the stochastic branches to be used for the nodes/units/connections in this group"],
-                              ["model", "output_horizon", "no", "yes_no", "Outputs the flows in the horizons. Used for testing the model."]]
-            add_parameters_manual(db,new_parameters)
-        elif next_version == 18:
-            new_parameters = [["group", "penalty_inertia", 5000, None, "[CUR/MWs] Penalty for violating the inertia constraint. Constant or period."],
-                              ["group", "penalty_capacity_margin", 5000, None, "[CUR/MWh] Penalty for violating the capacity margin constraint. Constant or period."],
-                              ["group", "penalty_non_synchronous", 5000, None, "[CUR/MWh] Penalty for violating the non synchronous constraint. Constant or period."]]
-            new_relationships = [["reserve__upDown__group", "penalty_reserve", 5000, None, "[CUR/MW] Penalty for violating a reserve constraint. Constant."]]
-            add_parameters_manual(db,new_parameters)
-            add_relationships_manual(db,new_relationships)
-        elif next_version == 19:
-            remove_parameters_manual(db, [["constraint", "is_active"], ["reserve__upDown__unit__node", "is_active"]])
-        elif next_version == 20:
-            remove_parameters_manual(db, [["connection", "is_active"], ["node", "is_active"], ["unit", "is_active"], ["reserve__upDown__connection", "is_active"]])
-        elif next_version == 21:
-            new_value_list = [["storage_nested_fix_method","fix_nothing"],["storage_nested_fix_method","fix_quantity"],["storage_nested_fix_method","fix_price"], ["storage_nested_fix_method","fix_usage"]]
-            add_value_list_manual(db,new_value_list)
-        elif next_version == 22:
-            db.add_update_item("parameter_value_list", name = "node_type")
-            add_value_list_manual(db,[["node_type","balance_within_period"],["invest_methods","cumulative_limits"]])
-            db.add_update_item("parameter_definition", entity_class_name= "node", name= "node_type", parameter_type_list = None, parameter_value_list_name = "node_type", description = "Selection for the node to have period balance, instead of time step balance.")
-            db.add_update_item("parameter_definition", entity_class_name= "node", name= "cumulative_max_capacity", parameter_type_list = None, description = "[MWh] Maximum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
-            db.add_update_item("parameter_definition", entity_class_name= "node", name= "cumulative_min_capacity", parameter_type_list = None, description = "[MWh] Minimum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
-            db.add_update_item("parameter_definition", entity_class_name= "connection", name= "cumulative_max_capacity", parameter_type_list = None, description = "[MW] Maximum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
-            db.add_update_item("parameter_definition", entity_class_name= "connection", name= "cumulative_min_capacity", parameter_type_list = None, description = "[MW] Minimum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
-            db.add_update_item("parameter_definition", entity_class_name= "unit", name= "cumulative_max_capacity", parameter_type_list = None, description = "[MW] Maximum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
-            db.add_update_item("parameter_definition", entity_class_name= "unit", name= "cumulative_min_capacity", parameter_type_list = None, description = "[MW] Minimum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
-            db.update_item("parameter_definition", entity_class_name= "node", name= "existing", description = "[MWh] Existing storage capacity. Constant or Period")
-            db.update_item("parameter_definition", entity_class_name= "connection", name= "existing", description = "[MW] Existing capacity. Constant or Period")
-            db.update_item("parameter_definition", entity_class_name= "unit", name= "existing", description = "[MW] Existing capacity. Constant or Period")
-            db.update_item("parameter_definition", entity_class_name= "node", name= "penalty_up", description = "[CUR/MW] Penalty cost for decreasing consumption in the node. Constant, Period or Time.")
-            db.update_item("parameter_definition", entity_class_name= "node", name= "penalty_down", description = "[CUR/MW] Penalty cost for increasing consumption in the node. Constant, Period or Time.")
-            db.update_item("parameter_definition", entity_class_name= "unit__outputNode", name= "other_operational_cost", description = "[CUR/MWh] Other operational variable cost for energy flows. Constant, Period or Time.")
-            db.update_item("parameter_definition", entity_class_name= "unit__inputNode", name= "other_operational_cost", description = "[CUR/MWh] Other operational variable cost for energy flows. Constant, Period or Time.")
-            db.update_item("parameter_definition", entity_class_name= "connection", name= "other_operational_cost", description = "[CUR/MWh] Other operational variable cost for trasferring over the connection. Constant, Period or time.")
-            db.update_item("parameter_definition", entity_class_name= "solve", name= "solve_mode", description = "A single_solve or rolling_window for a set of rolling optimisation windows solved in a sequence.")
-            db.commit_session("Added cumulative investments")
+    with DatabaseMapping('sqlite:///' + database_path, create = False, upgrade = True) as db:
+        sq= db.object_parameter_definition_sq
+        settings_parameter = db.query(sq).filter(sq.c.object_class_name == "model").filter(sq.c.parameter_name == "version").one_or_none()
+        if settings_parameter is None:
+            #if no version assume version 0
+            print("No version found. Assuming version 0, if older, migration might not work")
+            version = 0
         else:
-            print("Version invalid")
-        next_version += 1 
+            version = from_database(settings_parameter.default_value, settings_parameter.default_type)
 
-    if version < new_version:
-        version_up = [["model", "version", new_version, None, "Contains database version information."]]
-        (num,log) = import_data(db, object_parameters = version_up)
-        print(database_path+ " updated to version "+ str(new_version))
-        db.commit_session("Updated Flextool data structure to version " + str(new_version))
-    else:
-        print(database_path+ " already up-to-date at version "+ str(version))
+        next_version = int(version) + 1
+        new_version = 22
+
+        while next_version <= new_version:
+            if next_version == 0:
+                add_version(db)
+            elif next_version == 1:
+                add_new_parameters(db, './version/flextool_template_v2.json')
+            elif next_version == 2:
+                add_new_parameters(db, './version/flextool_template_rolling_window.json')
+            elif next_version == 3:
+                add_new_parameters(db, './version/flextool_template_lifetime_method.json')
+            elif next_version == 4:
+                add_new_parameters(db, './version/flextool_template_drop_down.json')
+            elif next_version == 5:
+                add_new_parameters(db, './version/flextool_template_optional_outputs.json')
+            elif next_version == 6:
+                add_new_parameters(db, './version/flextool_template_default_value.json')
+            elif next_version == 7:
+                add_new_parameters(db, './version/flextool_template_rolling_start_remove.json')
+            elif next_version == 8:
+                add_new_parameters(db, './version/flextool_template_output_node_flows.json')
+            elif next_version == 9:
+                add_new_parameters(db, './version/flextool_template_constant_default.json')
+            elif next_version == 10:
+                add_new_parameters(db, './version/flextool_template_storage_binding_defaults.json')
+            elif next_version == 11:
+                change_optional_output_type(db,'./version/flextool_template_default_optional_output.json')
+            elif next_version == 12:
+                new_parameters = [["group", "output_aggregate_flows", None, "output_node_flows", "Used with group_unit_node or group_connection_node to combine the flows when producing the output_node_flows of a node group."],
+                                  ["group", "output_node_flows", None, "output_node_flows" ,"Creates the timewise flow output for this node group (group_flow_t)"]]
+                add_parameters_manual(db,new_parameters)
+                remove_parameters_manual(db,[["solve","rolling_start_time"]])
+            elif next_version == 13:
+                new_value_list = [["load_share_type","equal"],["load_share_type","inflow_weighted"],["load_share_type","no"]]
+                new_parameters = [["group", "share_loss_of_load", "no", "load_share_type", "Force the upward slack of the nodes in this group to be equal or inflow (demand) weighted"]]
+                #value list needs to be added first
+                add_value_list_manual(db,new_value_list)
+                add_parameters_manual(db,new_parameters)
+                remove_parameters_manual(db,[["node","storate_state_end"]])
+            elif next_version == 14:
+                new_parameters = [["model","exclude_entity_outputs", "yes", "optional_output", "Excludes results on node, unit and connection level, but preserves group level results"]]
+                remove_parameters_manual(db, [["model","results"]])
+                add_parameters_manual(db, new_parameters)
+            elif next_version == 15:
+                remove_parameters_manual(db,[["unit", "invest_forced"], ["unit", "retire_forced"], ["connection", "invest_forced"], ["connection", "retire_forced"],
+                                             ["node", "invest_forced"], ["node", "retire_forced"]])
+                add_parameters_manual(db, [["group", "co2_max_period", "no_method", "co2_methods", "[tCO2] Annualized maximum limit for emitted CO2 in each period."]])
+            elif next_version == 16:
+                add_parameters_manual(db, [["group", "co2_max_period", None, None, "[tCO2] Annualized maximum limit for emitted CO2 in each period."]])
+            elif next_version == 17:
+                add_value_list_manual(db,[["yes_no", "yes"], ["yes_no", "no"]])
+                new_parameters = [["solve", "stochastic_branches", None, None, "[4d-Map], Sets branches included in the solve. [Period, branch, start_time (time_step), realized (yes/no), weight (number)]. Only one of the branches should be realized for each start_time"],
+                                  ["group", "include_stochastics", "no", "yes_no", "Includes the stochastic branches to be used for the nodes/units/connections in this group"],
+                                  ["model", "output_horizon", "no", "yes_no", "Outputs the flows in the horizons. Used for testing the model."]]
+                add_parameters_manual(db,new_parameters)
+            elif next_version == 18:
+                new_parameters = [["group", "penalty_inertia", 5000, None, "[CUR/MWs] Penalty for violating the inertia constraint. Constant or period."],
+                                  ["group", "penalty_capacity_margin", 5000, None, "[CUR/MWh] Penalty for violating the capacity margin constraint. Constant or period."],
+                                  ["group", "penalty_non_synchronous", 5000, None, "[CUR/MWh] Penalty for violating the non synchronous constraint. Constant or period."]]
+                new_relationships = [["reserve__upDown__group", "penalty_reserve", 5000, None, "[CUR/MW] Penalty for violating a reserve constraint. Constant."]]
+                add_parameters_manual(db,new_parameters)
+                add_relationships_manual(db,new_relationships)
+            elif next_version == 19:
+                remove_parameters_manual(db, [["constraint", "is_active"], ["reserve__upDown__unit__node", "is_active"]])
+            elif next_version == 20:
+                remove_parameters_manual(db, [["connection", "is_active"], ["node", "is_active"], ["unit", "is_active"], ["reserve__upDown__connection", "is_active"]])
+            elif next_version == 21:
+                new_value_list = [["storage_nested_fix_method","fix_nothing"],["storage_nested_fix_method","fix_quantity"],["storage_nested_fix_method","fix_price"], ["storage_nested_fix_method","fix_usage"]]
+                add_value_list_manual(db,new_value_list)
+            elif next_version == 22:
+                db.add_update_item("parameter_value_list", name = "node_type")
+                add_value_list_manual(db,[["node_type","balance_within_period"],["invest_methods","cumulative_limits"]])
+                db.add_update_item("parameter_definition", entity_class_name= "node", name= "node_type", parameter_type_list = None, parameter_value_list_name = "node_type", description = "Selection for the node to have period balance, instead of time step balance.")
+                db.add_update_item("parameter_definition", entity_class_name= "node", name= "cumulative_max_capacity", parameter_type_list = None, description = "[MWh] Maximum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
+                db.add_update_item("parameter_definition", entity_class_name= "node", name= "cumulative_min_capacity", parameter_type_list = None, description = "[MWh] Minimum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
+                db.add_update_item("parameter_definition", entity_class_name= "connection", name= "cumulative_max_capacity", parameter_type_list = None, description = "[MW] Maximum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
+                db.add_update_item("parameter_definition", entity_class_name= "connection", name= "cumulative_min_capacity", parameter_type_list = None, description = "[MW] Minimum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
+                db.add_update_item("parameter_definition", entity_class_name= "unit", name= "cumulative_max_capacity", parameter_type_list = None, description = "[MW] Maximum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
+                db.add_update_item("parameter_definition", entity_class_name= "unit", name= "cumulative_min_capacity", parameter_type_list = None, description = "[MW] Minimum cumulative capacity (considers existing, invested and retired capacity). Constant or period.")
+                db.update_item("parameter_definition", entity_class_name= "node", name= "existing", description = "[MWh] Existing storage capacity. Constant or Period")
+                db.update_item("parameter_definition", entity_class_name= "connection", name= "existing", description = "[MW] Existing capacity. Constant or Period")
+                db.update_item("parameter_definition", entity_class_name= "unit", name= "existing", description = "[MW] Existing capacity. Constant or Period")
+                db.update_item("parameter_definition", entity_class_name= "node", name= "penalty_up", description = "[CUR/MW] Penalty cost for decreasing consumption in the node. Constant, Period or Time.")
+                db.update_item("parameter_definition", entity_class_name= "node", name= "penalty_down", description = "[CUR/MW] Penalty cost for increasing consumption in the node. Constant, Period or Time.")
+                db.update_item("parameter_definition", entity_class_name= "unit__outputNode", name= "other_operational_cost", description = "[CUR/MWh] Other operational variable cost for energy flows. Constant, Period or Time.")
+                db.update_item("parameter_definition", entity_class_name= "unit__inputNode", name= "other_operational_cost", description = "[CUR/MWh] Other operational variable cost for energy flows. Constant, Period or Time.")
+                db.update_item("parameter_definition", entity_class_name= "connection", name= "other_operational_cost", description = "[CUR/MWh] Other operational variable cost for trasferring over the connection. Constant, Period or time.")
+                db.update_item("parameter_definition", entity_class_name= "solve", name= "solve_mode", description = "A single_solve or rolling_window for a set of rolling optimisation windows solved in a sequence.")
+                db.commit_session("Added cumulative investments")
+            else:
+                print("Version invalid")
+            next_version += 1
+
+        if version < new_version:
+            version_up = [["model", "version", new_version, None, "Contains database version information."]]
+            (num,log) = import_data(db, object_parameters = version_up)
+            print(database_path+ " updated to version "+ str(new_version))
+            db.commit_session("Updated Flextool data structure to version " + str(new_version))
+        else:
+            print(database_path+ " already up-to-date at version "+ str(version))
 
 def add_version(db):
     # this function adds the version information to the database if there is none


### PR DESCRIPTION
In the future, database mappings must be used inside `with` blocks when using their low-level query methods, see spine-tools/Spine-Database-API#473 This PR updates the Python scripts to do just that. No real functional changes intended