### PR TITLE
Delay fix

### DIFF
--- a/.spinetoolbox/project.json
+++ b/.spinetoolbox/project.json
@@ -22,11 +22,6 @@
                 {
                     "type": "path",
                     "relative": true,
-                    "path": ".spinetoolbox/specifications/Exporter/export_flextool3_csv.json"
-                },
-                {
-                    "type": "path",
-                    "relative": true,
                     "path": ".spinetoolbox/specifications/Exporter/results_to_excel.json"
                 }
             ],

--- a/.spinetoolbox/project.json
+++ b/.spinetoolbox/project.json
@@ -275,6 +275,9 @@
                     "FlexTool",
                     "left"
                 ],
+                "options": {
+                    "require_scenario_filter": true
+                },
                 "filter_settings": {
                     "known_filters": {
                         "db_url@Input_data": {

--- a/.spinetoolbox/specifications/Importer/import_flex3.json
+++ b/.spinetoolbox/specifications/Importer/import_flex3.json
@@ -73,370 +73,6 @@
                     }
                 }
             ],
-            "unit__outputNode__period": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "flow_annualized"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit__inputNode__period": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "flow_annualized"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
-            "process__reserve__upDown__node__period__t": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": -1
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": -2
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "reserve"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "upDown"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -3,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -4,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -5,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -6,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "reservation_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 7
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit__inputNode__period__t": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "flow_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
             "unit_online__period__t": [
                 {
                     "Mapping 1": {
@@ -502,97 +138,6 @@
                             {
                                 "map_type": "ExpandedValue",
                                 "position": "hidden"
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit__outputNode__period__t": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "flow_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
                             }
                         ]
                     }
@@ -1539,106 +1084,6 @@
                     }
                 }
             ],
-            "process__reserve__upDown__node__period_average": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": -1
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": -2
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "reserve"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "upDown"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -3,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -4,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -5,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -6,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "reservation_average"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 7
-                            }
-                        ]
-                    }
-                }
-            ],
             "slack__capacity_margin__period": [
                 {
                     "Mapping 1": {
@@ -1721,107 +1166,6 @@
                                 "map_type": "ParameterDefinition",
                                 "position": "hidden",
                                 "value": "slack_nonsync_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": "hidden"
-                            }
-                        ]
-                    }
-                }
-            ],
-            "slack__reserve__upDown__group__period__t": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "group__reserve__upDown"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "reserve"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "upDown"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "group"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -3,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "slack_reserve_t"
                             },
                             {
                                 "map_type": "Alternative",
@@ -1988,188 +1332,6 @@
                             {
                                 "map_type": "ExpandedValue",
                                 "position": "hidden"
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit_ramp__inputNode__dt": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "ramp_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit_ramp__outputNode__dt": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "ramp_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
                             }
                         ]
                     }
@@ -2700,190 +1862,6 @@
                     }
                 }
             ],
-            "reserve_price__upDown__group__period__t": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit_cf__inputNode__period": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "cf"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit_cf__outputNode__period": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "cf"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
             "connection_cf__period": [
                 {
                     "Mapping 1": {
@@ -3232,258 +2210,6 @@
                     }
                 }
             ],
-            "unit_curtailment_share__outputNode__period": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "curtailment_share"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "type"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
-            "unit_curtailment__outputNode__period__t": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "unit__node"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "unit"
-                            },
-                            {
-                                "map_type": "Dimension",
-                                "position": "hidden",
-                                "value": "node"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": "hidden",
-                                "value": "relationship"
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -1,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "Element",
-                                "position": -2,
-                                "import_entities": true
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "curtailment_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": 4
-                            }
-                        ]
-                    }
-                }
-            ],
-            "group_node_VRE_share__period__t": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "group"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": -1
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "VRE_share_t"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "time"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 2
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": "hidden"
-                            }
-                        ]
-                    }
-                }
-            ],
             "slack__downward__node_state__period__t": [
                 {
                     "Mapping 1": {
@@ -3664,67 +2390,6 @@
                             {
                                 "map_type": "ParameterValueIndex",
                                 "position": -3
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "solve"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 0
-                            },
-                            {
-                                "map_type": "IndexName",
-                                "position": "hidden",
-                                "value": "period"
-                            },
-                            {
-                                "map_type": "ParameterValueIndex",
-                                "position": 1
-                            },
-                            {
-                                "map_type": "ExpandedValue",
-                                "position": "hidden"
-                            }
-                        ]
-                    }
-                }
-            ],
-            "group_process_CO2__period": [
-                {
-                    "Mapping 1": {
-                        "mapping": [
-                            {
-                                "map_type": "EntityClass",
-                                "position": "hidden",
-                                "value": "group"
-                            },
-                            {
-                                "map_type": "Entity",
-                                "position": -1
-                            },
-                            {
-                                "map_type": "EntityMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterDefinition",
-                                "position": "hidden",
-                                "value": "CO2_annualized"
-                            },
-                            {
-                                "map_type": "Alternative",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueMetadata",
-                                "position": "hidden"
-                            },
-                            {
-                                "map_type": "ParameterValueType",
-                                "position": "hidden",
-                                "value": "map"
                             },
                             {
                                 "map_type": "IndexName",
@@ -5154,16 +3819,31 @@
                         ]
                     }
                 }
+            ],
+            "reserve_price__updown__group__period__t": [
+                {
+                    "Mapping 1": {
+                        "mapping": [
+                            {
+                                "map_type": "EntityClass",
+                                "position": "hidden"
+                            },
+                            {
+                                "map_type": "Entity",
+                                "position": "hidden"
+                            },
+                            {
+                                "map_type": "EntityMetadata",
+                                "position": "hidden"
+                            }
+                        ]
+                    }
+                }
             ]
         },
         "selected_tables": [
             "node__period",
-            "unit__outputNode__period",
-            "unit__inputNode__period",
-            "process__reserve__upDown__node__period__t",
-            "unit__inputNode__period__t",
             "unit_online__period__t",
-            "unit__outputNode__period__t",
             "connection__period__t",
             "connection__period",
             "node_capacity__period",
@@ -5176,14 +3856,10 @@
             "unit_capacity__period",
             "costs__period__t",
             "node_ramp__period__t",
-            "process__reserve__upDown__node__period_average",
             "slack__capacity_margin__period",
             "slack__nonsync_group__period__t",
-            "slack__reserve__upDown__group__period__t",
             "unit_online__period_average",
             "unit_startup__period",
-            "unit_ramp__inputNode__dt",
-            "unit_ramp__outputNode__dt",
             "slack__inertia_group__period__t",
             "process__period_co2",
             "connection_invest_marginal__period",
@@ -5192,21 +3868,15 @@
             "group_inertia_largest_flow__period__t",
             "group__process__node__period",
             "discount_factors__period",
-            "unit_cf__inputNode__period",
-            "unit_cf__outputNode__period",
             "connection_cf__period",
             "group__process__node__period__t",
             "costs_discounted",
             "costs_discounted__solve",
             "annualized_costs__period",
-            "unit_curtailment_share__outputNode__period",
-            "unit_curtailment__outputNode__period__t",
-            "group_node_VRE_share__period__t",
             "slack__downward__node_state__period__t",
             "slack__upward__node_state__period__t",
             "group_flows__period__t",
             "group_flows__period",
-            "group_process_CO2__period",
             "group__unit__node_inertia__period__t",
             "unit__outputnode__period",
             "unit__inputnode__period",
@@ -5227,9 +3897,6 @@
         "table_options": {
             "node__period": {},
             "connection_capacity__period": {},
-            "process__reserve__upDown__node__period__t": {
-                "has_header": false
-            },
             "node_prices__period__t": {
                 "has_header": false
             },
@@ -5238,16 +3905,10 @@
             "node_state__period__t": {
                 "has_header": false
             },
-            "unit__inputNode__period__t": {
-                "has_header": false
-            },
             "unit_online__period__t": {
                 "has_header": false
             },
             "group_node__period": {},
-            "unit__outputNode__period__t": {
-                "has_header": false
-            },
             "node_capacity__period": {},
             "connection__period": {
                 "has_header": false
@@ -5256,39 +3917,21 @@
                 "has_header": false
             },
             "unit_capacity__period": {},
-            "unit__outputNode__period": {
-                "has_header": false
-            },
             "connection__period__t": {
-                "has_header": false
-            },
-            "unit__inputNode__period": {
                 "has_header": false
             },
             "costs__period__t": {},
             "node_ramp__period__t": {},
-            "process__reserve__upDown__node__period_average": {
-                "has_header": false
-            },
             "slack__capacity_margin__period": {
                 "has_header": false
             },
             "slack__nonsync_group__period__t": {
                 "has_header": false
             },
-            "slack__reserve__upDown__group__period__t": {
-                "has_header": false
-            },
             "unit_online__period_average": {
                 "has_header": false
             },
             "unit_startup__period": {
-                "has_header": false
-            },
-            "unit_ramp__inputNode__dt": {
-                "has_header": false
-            },
-            "unit_ramp__outputNode__dt": {
                 "has_header": false
             },
             "slack__inertia_group__period__t": {
@@ -5314,13 +3957,6 @@
                 "has_header": false
             },
             "entity_annuity": {},
-            "reserve_price__upDown__group__period__t": {},
-            "unit_cf__inputNode__period": {
-                "has_header": false
-            },
-            "unit_cf__outputNode__period": {
-                "has_header": false
-            },
             "connection_cf__period": {
                 "has_header": false
             },
@@ -5333,25 +3969,13 @@
             "costs_discounted__solve": {
                 "has_header": false
             },
-            "unit_curtailment_share__outputNode__period": {
-                "has_header": false
-            },
-            "unit_curtailment__outputNode__period__t": {
-                "has_header": false
-            },
             "annualized_costs__period": {},
-            "group_node_VRE_share__period__t": {
-                "has_header": false
-            },
             "slack__downward__node_state__period__t": {},
             "slack__upward__node_state__period__t": {},
             "group_flows__period__t": {
                 "has_header": false
             },
             "group_flows__period": {
-                "has_header": false
-            },
-            "group_process_CO2__period": {
                 "has_header": false
             },
             "group__unit__node_inertia__period__t": {
@@ -5401,33 +4025,10 @@
             },
             "group_node_vre_share__period__t": {
                 "has_header": false
-            }
+            },
+            "reserve_price__updown__group__period__t": {}
         },
         "table_types": {
-            "unit__outputNode__period": {
-                "0": "string",
-                "1": "string",
-                "2": "float",
-                "3": "float"
-            },
-            "unit__inputNode__period": {
-                "0": "string",
-                "1": "string",
-                "2": "float"
-            },
-            "unit__inputNode__period__t": {
-                "0": "string",
-                "1": "string",
-                "2": "string",
-                "3": "float"
-            },
-            "unit__outputNode__period__t": {
-                "0": "string",
-                "1": "string",
-                "2": "string",
-                "3": "float",
-                "4": "float"
-            },
             "unit_capacity__period": {
                 "0": "string",
                 "1": "string",
@@ -5450,11 +4051,6 @@
                 "9": "float",
                 "10": "float",
                 "11": "float"
-            },
-            "process__reserve__upDown__node__period__t": {
-                "0": "string",
-                "1": "string",
-                "2": "string"
             },
             "connection__period__t": {
                 "0": "string",
@@ -5561,20 +4157,11 @@
                 "9": "float",
                 "10": "float"
             },
-            "process__reserve__upDown__node__period_average": {
-                "0": "string",
-                "1": "string"
-            },
             "slack__capacity_margin__period": {
                 "0": "string",
                 "1": "string"
             },
             "slack__nonsync_group__period__t": {
-                "0": "string",
-                "1": "string",
-                "2": "string"
-            },
-            "slack__reserve__upDown__group__period__t": {
                 "0": "string",
                 "1": "string",
                 "2": "string"
@@ -5586,19 +4173,6 @@
             "unit_startup__period": {
                 "0": "string",
                 "1": "string"
-            },
-            "unit_ramp__inputNode__dt": {
-                "0": "string",
-                "1": "string",
-                "2": "string",
-                "3": "float"
-            },
-            "unit_ramp__outputNode__dt": {
-                "0": "string",
-                "1": "string",
-                "2": "string",
-                "3": "float",
-                "4": "float"
             },
             "slack__inertia_group__period__t": {
                 "0": "string",
@@ -5640,22 +4214,6 @@
                 "2": "float",
                 "3": "float"
             },
-            "reserve_price__upDown__group__period__t": {
-                "0": "string",
-                "1": "string",
-                "2": "string"
-            },
-            "unit_cf__inputNode__period": {
-                "0": "string",
-                "1": "string",
-                "2": "float"
-            },
-            "unit_cf__outputNode__period": {
-                "0": "string",
-                "1": "string",
-                "2": "float",
-                "3": "float"
-            },
             "connection_cf__period": {
                 "0": "string",
                 "1": "string",
@@ -5689,18 +4247,6 @@
                 "14": "float",
                 "15": "float"
             },
-            "unit_curtailment_share__outputNode__period": {
-                "0": "string",
-                "1": "string",
-                "2": "string",
-                "3": "float"
-            },
-            "unit_curtailment__outputNode__period__t": {
-                "0": "string",
-                "1": "string",
-                "2": "string",
-                "3": "float"
-            },
             "annualized_costs__period": {
                 "0": "string",
                 "1": "string",
@@ -5724,12 +4270,6 @@
                 "0": "string",
                 "1": "string"
             },
-            "group_node_VRE_share__period__t": {
-                "0": "string",
-                "1": "string",
-                "2": "string",
-                "3": "float"
-            },
             "group_flows__period__t": {
                 "0": "string",
                 "1": "string",
@@ -5752,11 +4292,6 @@
                 "6": "float",
                 "7": "float",
                 "8": "float"
-            },
-            "group_process_CO2__period": {
-                "0": "string",
-                "1": "string",
-                "2": "float"
             },
             "group__unit__node_inertia__period__t": {
                 "0": "string",
@@ -5851,16 +4386,16 @@
                 "1": "string",
                 "2": "string",
                 "3": "float"
+            },
+            "reserve_price__updown__group__period__t": {
+                "0": "string",
+                "1": "string",
+                "2": "string"
             }
         },
         "table_default_column_type": {
             "node__period": "float",
-            "unit__outputNode__period": "float",
-            "unit__inputNode__period": "float",
-            "process__reserve__upDown__node__period__t": "float",
-            "unit__inputNode__period__t": "float",
             "unit_online__period__t": "float",
-            "unit__outputNode__period__t": "float",
             "connection__period__t": "float",
             "connection__period": "float",
             "node_capacity__period": "float",
@@ -5872,64 +4407,29 @@
             "group_inertia__period__t": "float",
             "costs__period__t": "float",
             "node_ramp__period__t": "float",
-            "process__reserve__upDown__node__period_average": "float",
             "slack__capacity_margin__period": "float",
             "slack__nonsync_group__period__t": "float",
-            "slack__reserve__upDown__group__period__t": "float",
             "unit_online__period_average": "float",
             "unit_startup__period": "float",
-            "unit_ramp__inputNode__dt": "float",
-            "unit_ramp__outputNode__dt": "float",
             "slack__inertia_group__period__t": "float",
             "process__period_co2": "float",
             "group__process__node__period": "float",
-            "unit_curtailment__outputNode__period__t": "float",
-            "group_node_VRE_share__period__t": "float",
-            "unit_curtailment_share__outputNode__period": "float",
             "annualized_costs__period": "float",
             "group__process__node__period__t": "float",
             "costs_discounted": "float",
             "connection_cf__period": "float",
-            "unit_cf__outputNode__period": "float",
-            "unit_cf__inputNode__period": "float",
             "group_inertia_largest_flow__period__t": "float",
             "unit_invest_marginal__period": "float",
             "node_invest_marginal__period": "float",
             "connection_invest_marginal__period": "float",
             "unit_capacity__period": "float",
             "group_flows__period__t": "float",
-            "group_process_CO2__period": "float",
             "group_flows__period": "float"
         },
         "table_row_types": {
-            "unit__outputNode__period": {
-                "1": "string",
-                "0": "string"
-            },
-            "unit__inputNode__period": {
-                "1": "string",
-                "0": "string"
-            },
-            "unit__outputNode__period__t": {
-                "1": "string",
-                "0": "string",
-                "2": "string"
-            },
             "connection__period": {
                 "1": "string",
                 "2": "string"
-            },
-            "unit__inputNode__period__t": {
-                "1": "string",
-                "0": "string",
-                "2": "string"
-            },
-            "process__reserve__upDown__node__period__t": {
-                "1": "string",
-                "2": "string",
-                "3": "string",
-                "4": "string",
-                "5": "string"
             },
             "connection__period__t": {
                 "1": "string",
@@ -5939,34 +4439,7 @@
                 "1": "string",
                 "0": "string"
             },
-            "process__reserve__upDown__node__period_average": {
-                "1": "string",
-                "2": "string",
-                "3": "string",
-                "4": "string",
-                "5": "string"
-            },
-            "slack__reserve__upDown__group__period__t": {
-                "1": "string",
-                "2": "string"
-            },
-            "unit_ramp__inputNode__dt": {
-                "1": "string",
-                "0": "string"
-            },
-            "unit_ramp__outputNode__dt": {
-                "1": "string",
-                "0": "string"
-            },
             "group_inertia_largest_flow__period__t": {
-                "1": "string",
-                "0": "string"
-            },
-            "unit_cf__inputNode__period": {
-                "1": "string",
-                "0": "string"
-            },
-            "unit_cf__outputNode__period": {
                 "1": "string",
                 "0": "string"
             },

--- a/flextool/flextoolrunner.py
+++ b/flextool/flextoolrunner.py
@@ -1049,22 +1049,23 @@ class FlexToolRunner:
         for (entity, delay_durations) in self.delay_durations.items():
             if isinstance(delay_durations, list):
                 for delay_duration in delay_durations:
-                    delay_duration_set.add(delay_duration[0])
+                    delay_duration_set.add(str(delay_duration[0]))
             else:
-                delay_duration_set.add(delay_durations)
+                delay_duration_set.add(str(delay_durations))
         with open("solve_data/delay_duration.csv", 'w') as realfile:
             realfile.write("delay_duration\n")
             for delay_duration in delay_duration_set:
                 realfile.write(str(delay_duration)+"\n")
-        with open("solve_data/tt__delay_duration.csv", 'w') as realfile:
-            realfile.write("time_source,time_sink,delay_duration\n")
-            for timeblockSet_name, timeblockSet in list(self.timeblocks.items()):
-                timeline_name = self.timeblocks__timeline[timeblockSet_name][0]
-                time_steps = self.timelines[timeline_name]
+        with open("solve_data/dtt__delay_duration.csv", 'w') as realfile:
+            realfile.write("period,time_source,time_sink,delay_duration\n")
+            for period_name, time_steps in active_time_list.items():
                 for k, time_step in enumerate(time_steps):
                     for delay_duration in delay_duration_set:
                         if k + int(float(delay_duration)) < len(time_steps):
-                            row = ','.join([time_step[0], time_steps[k+int(float(delay_duration))][0], str(delay_duration)])
+                            row = ','.join([period_name, time_step[0], time_steps[k + int(float(delay_duration))][0], str(delay_duration)])
+                            realfile.write(row+"\n")
+                        elif k + int(float(delay_duration)) >= len(time_steps):
+                            row = ','.join([period_name, time_step[0], time_steps[k - len(time_steps) + int(float(delay_duration))][0], str(delay_duration)])
                             realfile.write(row+"\n")
 
     @staticmethod


### PR DESCRIPTION
Makes multiple delays work at the same time (flextoolrunner was creating multiple sets). 

It also makes delays work with minimum flow constraints. Previously, delay meant that there was no flow in the first time steps of the model (due to the delay). Now delay wraps around the active timeline (from end to beginning). As a consequence, the model can stay feasible.