### PR TITLE
Speedup on using spine db api

### DIFF
--- a/flextool/flextool.mod
+++ b/flextool/flextool.mod
@@ -4924,7 +4924,7 @@ for {i in 1..1 : p_model['solveFirst']}
     printf '"state change","self discharge","upward slack","downward slack"\n' >> fn_node__dt; }  # Print the header on the first solve
 for {s in solve_current: 'output_node_balance_t' in enable_optional_outputs && 'yes' not in exclude_entity_outputs}
   { for {n in node, (d, t) in dt_realize_dispatch}
-    { printf '%s,%s,%s,%s,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g\n'
+    { printf '%s,%s,%s,%s,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.8g,%.8g\n'
       , n, s, d, t
           , + (if (n, 'no_inflow') not in node__inflow_method && n in nodeBalance union nodeBalancePeriod then pdtNodeInflow[n, d, t])
         , sum{(p, source, n) in process_source_sink_alwaysProcess : p in process_unit} r_process__source__sink_Flow__dt[p, source, n, d, t]

--- a/run_flextool.py
+++ b/run_flextool.py
@@ -5,6 +5,7 @@ import traceback
 import importlib.util
 from typing import Callable
 from functools import wraps
+import time
 
 class FlushingStream:
     def __init__(self, stream):
@@ -51,19 +52,24 @@ def main():
         format='%(levelname)s:%(filename)s:%(lineno)d:%(message)s',
         handlers=[logging.StreamHandler(sys.stdout)]
     )
-
+    start_time = time.time()
     if scenario_name:
         runner = flextoolrunner.FlexToolRunner(input_db_url, scenario_name)
+        print("--- Init time %s seconds ---" % (time.time() - start_time))
         runner.write_input(input_db_url, scenario_name)
+        print("--- write time %s seconds ---" % (time.time() - start_time))
     else:
         runner = flextoolrunner.FlexToolRunner(input_db_url)
+        print("--- Init time %s seconds ---" % (time.time() - start_time))
         runner.write_input(input_db_url)
+        print("--- write time %s seconds ---" % (time.time() - start_time))
     try:
         return_code = runner.run_model()
     except Exception as e:
         logging.error(f"Model run failed: {str(e)}\nTraceback:\n{traceback.format_exc()}")
         sys.exit(1)
     print(__file__)
+    print("--- full time %s seconds ---" % (time.time() - start_time))
 
 
 # Debug flag


### PR DESCRIPTION
Speed up by:
Use the new db.find_ instead of the ole db.get_
Fetching all parameter_values and entities first. With the find methods, this changes the flextool to only fetch the information once. Previously, it fetched information at every get_parameter_values() call.
Speed up on large databases on the reading and writing python phase from 600s to 10s