### PR TITLE
Fix connection group outputs

### DIFF
--- a/flextool/flextool.mod
+++ b/flextool/flextool.mod
@@ -4080,10 +4080,10 @@ for {s in solve_current, d in d_realized_period}
   for {g in groupOutput_process}
     {
       printf ',%.8g', 
-          + sum{(p, source, n) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_sink} 
-                r_process_source_sink_flow_d[p, source, n, d] / complete_period_share_of_year[d] 
-          - sum{(p, n, sink) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_source}
-              r_process_source_sink_flow_d[p, n, sink, d] / complete_period_share_of_year[d]
+          + sum{(p, p_source, n_sink) in process_source_sink_alwaysProcess : (g, p, n_sink) in group_process_node}
+                 r_process__source__sink_Flow__d[p, p_source, n_sink, d] / complete_period_share_of_year[d]
+          - sum{(p, n_source, p_sink) in process_source_sink_alwaysProcess : (g, p, n_source) in group_process_node}
+		         r_process__source__sink_Flow__d[p, n_source, p_sink, d] / complete_period_share_of_year[d]
       >> fn_groupProcessNode__d;
     }
   }
@@ -4104,10 +4104,10 @@ for {s in solve_current, (d, t) in dt_realize_dispatch}
 	for {g in groupOutput_process}
 	  {
 	    printf ',%.8g',
-         + sum{(p, source, n) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_sink} 
-	             r_process__source__sink_Flow__dt[p, source, n, d, t]
-         - sum{(p, n, sink) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_source}
-		         r_process__source__sink_Flow__dt[p, n, sink, d, t]
+         + sum{(p, p_source, n_sink) in process_source_sink_alwaysProcess : (g, p, n_sink) in group_process_node}
+	             r_process__source__sink_Flow__dt[p, p_source, n_sink, d, t]
+         - sum{(p, n_source, p_sink) in process_source_sink_alwaysProcess : (g, p, n_source) in group_process_node}
+		         r_process__source__sink_Flow__dt[p, n_source, p_sink, d, t]
 	    >> fn_groupProcessNode__dt;
 	  }
   }
@@ -5504,4 +5504,6 @@ display v_invest, v_divest, solve_current, total_cost;
 #display test_dt;
 #display {n in nodeBalancePeriod, (d, t) in dt}: vq_state_up[n, d, t].val * node_capacity_for_scaling[n, d];
 #display {n in nodeBalancePeriod, (d, t) in dt}: pdtNodeInflow[n, d, t];
+display process_source_sink_alwaysProcess, r_process__source__sink_Flow__dt;
+
 end;

--- a/flextool/flextool.mod
+++ b/flextool/flextool.mod
@@ -5504,6 +5504,5 @@ display v_invest, v_divest, solve_current, total_cost;
 #display test_dt;
 #display {n in nodeBalancePeriod, (d, t) in dt}: vq_state_up[n, d, t].val * node_capacity_for_scaling[n, d];
 #display {n in nodeBalancePeriod, (d, t) in dt}: pdtNodeInflow[n, d, t];
-display process_source_sink_alwaysProcess, r_process__source__sink_Flow__dt;
 
 end;

--- a/flextool/flextool.mod
+++ b/flextool/flextool.mod
@@ -3701,7 +3701,7 @@ param r_group_output__group_aggregate_Group_to_unit__d{(g, ga) in group_output__
 param r_group_output__group_aggregate_Connection__dt{(g, ga) in group_output__group_aggregate_Connection, (d, t) in dt_realize_dispatch} :=
   + sum{(g, ga, c, source, sink) in group_output__group_aggregate__process__connection__to_node}
     ( + r_process__source__sink_Flow__dt[c, c, sink, d, t])
-  - sum{(g, ga, c, source, sink) in group_output__group_aggregate__process__node__to_connection}
+  + sum{(g, ga, c, source, sink) in group_output__group_aggregate__process__node__to_connection}
     ( - r_process__source__sink_Flow__dt[c, source, c, d, t]);
 param r_group_output__group_aggregate_Connection__d{(g, ga) in group_output__group_aggregate_Connection, d in d_realized_period} :=
   + sum{(d, t) in dt_realize_dispatch} r_group_output__group_aggregate_Connection__dt[g, ga, d, t];

--- a/flextool/flextool.mod
+++ b/flextool/flextool.mod
@@ -1670,7 +1670,7 @@ param p_flow_min{(p, source, sink, d, t) in peedt} :=
   else 0
 ;
 
-set process_VRE := {p in process_unit : not (sum{(p, source) in process_source} 1)
+set process_VRE := {p in process_unit : sum{(p, source) in process_source} 1 == 0
                                         && (sum{(p, n, prof, m) in process__node__profile__profile_method : m = 'upper_limit'} 1)};
 
 param p_state_slack_share{(g,n) in group_node, (d,t) in dt: g in group_loss_share} :=
@@ -3701,7 +3701,7 @@ param r_group_output__group_aggregate_Group_to_unit__d{(g, ga) in group_output__
 param r_group_output__group_aggregate_Connection__dt{(g, ga) in group_output__group_aggregate_Connection, (d, t) in dt_realize_dispatch} :=
   + sum{(g, ga, c, source, sink) in group_output__group_aggregate__process__connection__to_node}
     ( + r_process__source__sink_Flow__dt[c, c, sink, d, t])
-  + sum{(g, ga, c, source, sink) in group_output__group_aggregate__process__node__to_connection}
+  - sum{(g, ga, c, source, sink) in group_output__group_aggregate__process__node__to_connection}
     ( - r_process__source__sink_Flow__dt[c, source, c, d, t]);
 param r_group_output__group_aggregate_Connection__d{(g, ga) in group_output__group_aggregate_Connection, d in d_realized_period} :=
   + sum{(d, t) in dt_realize_dispatch} r_group_output__group_aggregate_Connection__dt[g, ga, d, t];
@@ -4082,7 +4082,7 @@ for {s in solve_current, d in d_realized_period}
       printf ',%.8g', 
           + sum{(p, source, n) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_sink} 
                 r_process_source_sink_flow_d[p, source, n, d] / complete_period_share_of_year[d] 
-          + sum{(p, n, sink) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_source} 
+          - sum{(p, n, sink) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_source}
               r_process_source_sink_flow_d[p, n, sink, d] / complete_period_share_of_year[d]
       >> fn_groupProcessNode__d;
     }
@@ -4106,7 +4106,7 @@ for {s in solve_current, (d, t) in dt_realize_dispatch}
 	    printf ',%.8g',
          + sum{(p, source, n) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_sink} 
 	             r_process__source__sink_Flow__dt[p, source, n, d, t]
-         + sum{(p, n, sink) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_source} 
+         - sum{(p, n, sink) in process_source_sink_alwaysProcess : (g, p, n) in group_process_node && (p, n) in process_source}
 		         r_process__source__sink_Flow__dt[p, n, sink, d, t]
 	    >> fn_groupProcessNode__dt;
 	  }
@@ -4676,7 +4676,7 @@ for {s in solve_current, d in d_realized_period : 'yes' not in exclude_entity_ou
     for {(c, input, output) in process_source_sink : c in process_connection && (c, output) in process_sink}
 	  { printf ',%.6f', sum{(d, t) in dt_realize_dispatch} ( if entity_all_capacity[c, d] 
 	                                        then ( abs(r_connection_dt[c, d, t]) 
-	                                               / complete_hours_in_period[d] 
+	                                               / complete_hours_in_period[d]
 											       / entity_all_capacity[c, d] )
 										    else 0 ) >> fn_connection_cf__d; }
   }
@@ -5504,5 +5504,4 @@ display v_invest, v_divest, solve_current, total_cost;
 #display test_dt;
 #display {n in nodeBalancePeriod, (d, t) in dt}: vq_state_up[n, d, t].val * node_capacity_for_scaling[n, d];
 #display {n in nodeBalancePeriod, (d, t) in dt}: pdtNodeInflow[n, d, t];
-
 end;


### PR DESCRIPTION
group__process__node outputs had issues both with 'transmission line' type connections and with 'battery' type connections. 

When the group__process__node gets something like these:
connections__west-east__west
connections__west-east__east
It should sum outgoing and incoming flow for west and then also sum outgoing and incoming flow for east. These are further summed as group members and the end result is the losses of the connection.

When the group__process__node gets this:
storages__battery1__west
It should sum the outgoing and incoming flow from the persective of the west node. This gets losses correctly but also shows how the battery charges and discharges towards the electricity grid (which of interest to this group).

Neither of these were working, but now they are.