### PR TITLE
release: 4.0.1 — Spine Toolbox install & detection fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## Release 4.0.1 (1.9.2026) — Spine Toolbox install & detection fixes
+
+Patch release fixing the in-app Spine Toolbox install flow (all GUI, no schema
+or model changes).
+
+- **Install Spine Toolbox from the GUI now works.** The install action was tied
+  to the "Update FlexTool" button, which is disabled when FlexTool is already the
+  latest — so on a fresh install (always the latest) the Spine Toolbox extra
+  could never be installed. It is now a dedicated **"Install Spine Toolbox"**
+  button, shown only when Toolbox is missing, that installs just the extra
+  independent of any version update (`pip install "flextool[toolbox]"`, or the
+  editable `-e ".[toolbox]"` in a git checkout).
+- **Environment-scoped Toolbox detection and launch.** `toolbox_installed()` no
+  longer falls back to a PATH lookup for `spine-db-editor`, which reported
+  "installed" when a copy from a *different* environment was on PATH even though
+  Spine Toolbox was not in the venv running FlexTool. Detection now checks only
+  the current environment, and the Spine DB Editor is launched from it
+  (`python -m spinetoolbox.spine_db_editor.main`) rather than a PATH executable —
+  so the dialog and the open-`.sqlite` path agree.
+- **Docs.** The recommended install now pulls the Spine Toolbox and result-viewer
+  extras (`pip install "flextool[toolbox,viewer]"`); a note explains that plain
+  `pip install flextool` gives a spreadsheet-only install without the Spine DB
+  Editor.
+
 ## Release 4.0.0 (31.8.2026) — first stable v4: pip-installable; net-load representative-period clustering (schema v68); dispatch-plot & colors GUI rework; multi-use storage & existing-capacity output fixes
 
 This is the first stable **4.0.0** release. FlexTool is now **pip-installable**

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ terminal so the new PATH takes effect.
 
 Install FlexTool into a virtual environment to keep its packages separate from
 other Python applications. If you want to install into the base Python (perhaps
-because you do not otherwise use Python), just run the last command from below,
-`pip install flextool`.
+because you do not otherwise use Python), just run the last `pip install`
+command from below.
 
 ```
 python -m venv .venv        # Windows: py -m venv .venv
@@ -97,8 +97,13 @@ python -m venv .venv        # Windows: py -m venv .venv
 #            Windows CMD:         .\.venv\Scripts\activate.bat
 #            Linux / macOS:       . .venv/bin/activate
 python -m pip install --upgrade pip
-pip install flextool
+pip install "flextool[toolbox,viewer]"
 ```
+
+The `[toolbox,viewer]` extras add the Spine Toolbox database editor (for editing
+and viewing input and result databases) and the network-graph result view. To
+install without Spine Toolbox (edit/view data in a spreadsheet only), you can
+use plain `pip install flextool`.
 
 Your prompt should now show `(.venv)`. Verify with `python --version` — it
 should report 3.11 or newer.

--- a/flextool/gui/dialogs/update_dialog.py
+++ b/flextool/gui/dialogs/update_dialog.py
@@ -34,6 +34,7 @@ class UpdateDialog(tk.Toplevel):
         install_description: str,
         is_git: bool,
         default_toolbox: bool,
+        toolbox_installed: bool,
         check_on_startup: bool,
         update_available: bool | None,
         check_fn: Callable[[], bool],
@@ -46,6 +47,7 @@ class UpdateDialog(tk.Toplevel):
 
         self.proceed: bool = False
         self.include_toolbox: bool = default_toolbox
+        self._toolbox_installed: bool = toolbox_installed
         self.check_on_startup: bool = check_on_startup
         self.update_available: bool | None = update_available
         self._initial_check_on_startup: bool = check_on_startup
@@ -81,6 +83,7 @@ class UpdateDialog(tk.Toplevel):
 
         ttk.Checkbutton(
             body, text="Install Spine Toolbox", variable=self._toolbox_var,
+            command=self._render_availability,
         ).pack(anchor="w")
         ttk.Label(
             body,
@@ -139,14 +142,27 @@ class UpdateDialog(tk.Toplevel):
 
     # ── Availability state ──────────────────────────────────────────
 
+    def _pending_toolbox_install(self) -> bool:
+        """The user wants Spine Toolbox but it isn't installed yet — a valid
+        action (``pip install flextool[toolbox]``) even when FlexTool itself is
+        already up to date."""
+        return bool(self._toolbox_var.get()) and not self._toolbox_installed
+
     def _render_availability(self) -> None:
-        """Reflect ``update_available`` in the status label and Update button."""
+        """Reflect ``update_available`` (and a pending toolbox install) in the
+        status label and Update button."""
         if self.update_available is True:
             self._status_var.set("Status: a newer version is available.")
             self._set_update_enabled(True)
         elif self.update_available is False:
-            self._status_var.set("Status: you are up to date.")
-            self._set_update_enabled(False)
+            if self._pending_toolbox_install():
+                self._status_var.set(
+                    "Status: FlexTool is up to date — Spine Toolbox will be installed."
+                )
+                self._set_update_enabled(True)
+            else:
+                self._status_var.set("Status: you are up to date.")
+                self._set_update_enabled(False)
         else:
             self._status_var.set(
                 "Status: not checked — click Check to look for updates."

--- a/flextool/gui/dialogs/update_dialog.py
+++ b/flextool/gui/dialogs/update_dialog.py
@@ -46,7 +46,10 @@ class UpdateDialog(tk.Toplevel):
         self.resizable(False, False)
 
         self.proceed: bool = False
-        self.include_toolbox: bool = default_toolbox
+        # For an Update: keep Spine Toolbox current if it is already installed.
+        self.include_toolbox: bool = toolbox_installed
+        # Set True by the dedicated "Install Spine Toolbox" button.
+        self.install_toolbox: bool = False
         self._toolbox_installed: bool = toolbox_installed
         self.check_on_startup: bool = check_on_startup
         self.update_available: bool | None = update_available
@@ -54,7 +57,6 @@ class UpdateDialog(tk.Toplevel):
         self._check_fn = check_fn
         self._post_to_main = post_to_main
 
-        self._toolbox_var = tk.BooleanVar(value=default_toolbox)
         self._check_startup_var = tk.BooleanVar(value=check_on_startup)
         self._status_var = tk.StringVar()
 
@@ -81,21 +83,31 @@ class UpdateDialog(tk.Toplevel):
             body, textvariable=self._status_var, wraplength=440, justify="left",
         ).pack(anchor="w", pady=(0, 8))
 
-        ttk.Checkbutton(
-            body, text="Install Spine Toolbox", variable=self._toolbox_var,
-            command=self._render_availability,
-        ).pack(anchor="w")
-        ttk.Label(
-            body,
-            text=(
-                "Spine Toolbox is a large optional dependency. It is required "
-                "to open .sqlite input sources in the Spine DB Editor. Leave "
-                "unchecked if you do not need it."
-            ),
-            wraplength=440,
-            justify="left",
-            foreground="#888888",
-        ).pack(anchor="w", padx=(24, 0), pady=(0, 8))
+        if not toolbox_installed:
+            ttk.Label(
+                body,
+                text=(
+                    "Spine Toolbox is not installed. It is a large optional "
+                    "dependency required to open .sqlite input sources in the "
+                    "Spine DB Editor."
+                ),
+                wraplength=440,
+                justify="left",
+                foreground="#888888",
+            ).pack(anchor="w", pady=(0, 4))
+            ttk.Button(
+                body,
+                text="Install Spine Toolbox",
+                command=self._on_install_toolbox,
+            ).pack(anchor="w", pady=(0, 8))
+        else:
+            ttk.Label(
+                body,
+                text="Spine Toolbox is installed.",
+                wraplength=440,
+                justify="left",
+                foreground="#888888",
+            ).pack(anchor="w", pady=(0, 8))
 
         ttk.Label(
             body,
@@ -142,27 +154,14 @@ class UpdateDialog(tk.Toplevel):
 
     # ── Availability state ──────────────────────────────────────────
 
-    def _pending_toolbox_install(self) -> bool:
-        """The user wants Spine Toolbox but it isn't installed yet — a valid
-        action (``pip install flextool[toolbox]``) even when FlexTool itself is
-        already up to date."""
-        return bool(self._toolbox_var.get()) and not self._toolbox_installed
-
     def _render_availability(self) -> None:
-        """Reflect ``update_available`` (and a pending toolbox install) in the
-        status label and Update button."""
+        """Reflect ``update_available`` in the status label and Update button."""
         if self.update_available is True:
             self._status_var.set("Status: a newer version is available.")
             self._set_update_enabled(True)
         elif self.update_available is False:
-            if self._pending_toolbox_install():
-                self._status_var.set(
-                    "Status: FlexTool is up to date — Spine Toolbox will be installed."
-                )
-                self._set_update_enabled(True)
-            else:
-                self._status_var.set("Status: you are up to date.")
-                self._set_update_enabled(False)
+            self._status_var.set("Status: you are up to date.")
+            self._set_update_enabled(False)
         else:
             self._status_var.set(
                 "Status: not checked — click Check to look for updates."
@@ -202,9 +201,18 @@ class UpdateDialog(tk.Toplevel):
 
     # ── Button handlers ─────────────────────────────────────────────
 
+    def _on_install_toolbox(self) -> None:
+        """Install only the Spine Toolbox extra, regardless of FlexTool version."""
+        self.proceed = True
+        self.install_toolbox = True
+        self.include_toolbox = True
+        self.check_on_startup = bool(self._check_startup_var.get())
+        self._close()
+
     def _on_update(self) -> None:
         self.proceed = True
-        self.include_toolbox = bool(self._toolbox_var.get())
+        # include_toolbox already reflects whether Toolbox is installed (kept
+        # current during the update); install_toolbox stays False.
         self.check_on_startup = bool(self._check_startup_var.get())
         self._close()
 

--- a/flextool/gui/main_window.py
+++ b/flextool/gui/main_window.py
@@ -3196,16 +3196,25 @@ class MainWindow(tk.Tk):
         if not dlg.proceed:
             return
 
-        steps, cwd = install_info.upgrade_steps(dlg.include_toolbox)
+        if dlg.install_toolbox:
+            steps, cwd = install_info.install_toolbox_steps()
+            description = "Install Spine Toolbox"
+            intro = "Installing Spine Toolbox…\n"
+        else:
+            steps, cwd = install_info.upgrade_steps(dlg.include_toolbox)
+            description = "Update FlexTool"
+            intro = (
+                "Updating FlexTool"
+                + (" with Spine Toolbox" if dlg.include_toolbox else "")
+                + "…\n"
+            )
         self._run_cli_job(
             steps,
             job_type=JobType.UPDATE,
-            description="Update FlexTool",
+            description=description,
             action_key="update_flextool",
             cwd=cwd,
-            intro="Updating FlexTool"
-            + (" with Spine Toolbox" if dlg.include_toolbox else "")
-            + "…\n",
+            intro=intro,
             on_finish=self._update_finished,
         )
 

--- a/flextool/gui/main_window.py
+++ b/flextool/gui/main_window.py
@@ -3126,14 +3126,15 @@ class MainWindow(tk.Tk):
                 # spine-db-editor not found: point at 'Update FlexTool' and
                 # offer the system default .sqlite app as a fallback.
                 # askyesnocancel: Yes=Update, No=default app, Cancel=nothing.
+                from flextool.update_flextool import install_info
                 choice = messagebox.askyesnocancel(
                     "Spine DB Editor not available",
                     "The 'spine-db-editor' command was not found, so .sqlite "
                     "input sources cannot be opened in the Spine DB Editor.\n\n"
                     "It is part of Spine Toolbox. You can install it via "
                     "'Update FlexTool' (tick 'Install Spine Toolbox'), or "
-                    'manually from the flextool directory:\n\n'
-                    '  pip install -e ".[toolbox]"\n\n'
+                    "manually:\n\n"
+                    f"  {install_info.manual_toolbox_command()}\n\n"
                     "Open 'Update FlexTool' now?\n\n"
                     "Choose 'No' to open the file with your system's default "
                     "application for .sqlite files instead.",
@@ -3175,6 +3176,7 @@ class MainWindow(tk.Tk):
             install_description=install_info.describe_install(),
             is_git=install_info.is_git_install(),
             default_toolbox=default_toolbox,
+            toolbox_installed=install_info.toolbox_installed(),
             check_on_startup=self.global_settings.check_updates_on_startup,
             update_available=self._update_available,
             check_fn=install_info.update_available,
@@ -3284,6 +3286,7 @@ class MainWindow(tk.Tk):
             if self.execution_window is not None:
                 self.execution_window.select_job(job.job_id)
 
+        from flextool.update_flextool import install_info
         if messagebox.askyesno(
             "Could not open database",
             "The Spine DB Editor failed to start, so the database could not "
@@ -3292,7 +3295,7 @@ class MainWindow(tk.Tk):
             "The full error is shown in the Execution window. You can "
             "(re)install Spine Toolbox via 'Update FlexTool' (tick 'Install "
             "Spine Toolbox'), or manually:\n\n"
-            '  pip install -e ".[toolbox]"\n\n'
+            f"  {install_info.manual_toolbox_command()}\n\n"
             "Open 'Update FlexTool' now?",
             parent=self,
         ):

--- a/flextool/gui/platform_utils.py
+++ b/flextool/gui/platform_utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -95,24 +94,28 @@ def open_folder(dirpath: Path) -> None:
 
 
 def open_spine_db_editor(db_url: str) -> subprocess.Popen | None:
-    """Launch spine-db-editor as a subprocess.
-
-    Command: ``spine-db-editor <db_url>``
+    """Launch the Spine DB editor on *db_url* as a subprocess, using the current
+    environment's Spine Toolbox (``python -m spinetoolbox.spine_db_editor.main``,
+    matching the CLI launcher) rather than a ``spine-db-editor`` found anywhere
+    on PATH.
 
     Returns:
-        The :class:`subprocess.Popen` object, or ``None`` if
-        ``spine-db-editor`` is not found on the system PATH.
+        The :class:`subprocess.Popen` object, or ``None`` if Spine Toolbox is
+        not installed in this environment.
     """
-    exe = shutil.which("spine-db-editor")
-    if exe is None:
-        logger.warning("spine-db-editor not found on PATH")
+    import importlib.util
+
+    if importlib.util.find_spec("spinetoolbox") is None:
+        logger.warning("spinetoolbox is not installed in this environment")
         return None
 
     try:
-        proc = subprocess.Popen([exe, db_url])
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "spinetoolbox.spine_db_editor.main", db_url]
+        )
         return proc
     except OSError:
-        logger.warning("Failed to launch spine-db-editor", exc_info=True)
+        logger.warning("Failed to launch the Spine DB editor", exc_info=True)
         return None
 
 

--- a/flextool/update_flextool/install_info.py
+++ b/flextool/update_flextool/install_info.py
@@ -84,6 +84,17 @@ def manual_toolbox_command() -> str:
     return 'pip install "flextool[toolbox]"'
 
 
+def install_toolbox_steps() -> tuple[list[list[str]], Path | None]:
+    """Command(s) to install *just* the Spine Toolbox extra, without updating
+    FlexTool itself. Editable ``-e .[toolbox]`` (run in the repo root) for a git
+    checkout, otherwise the PyPI ``flextool[toolbox]`` form."""
+    py = sys.executable
+    root = git_checkout_root()
+    if root is not None:
+        return [[py, "-m", "pip", "install", "-e", ".[toolbox]"]], root
+    return [[py, "-m", "pip", "install", "flextool[toolbox]"]], None
+
+
 def upgrade_steps(include_toolbox: bool) -> tuple[list[list[str]], Path | None]:
     """Build the command(s) that upgrade FlexTool in place.
 

--- a/flextool/update_flextool/install_info.py
+++ b/flextool/update_flextool/install_info.py
@@ -74,6 +74,16 @@ def describe_install() -> str:
     return f"PyPI install (version {flextool_version()})"
 
 
+def manual_toolbox_command() -> str:
+    """Shell command a user can run by hand to add Spine Toolbox, matched to the
+    current install type — editable ``-e .[toolbox]`` in a git checkout (running
+    the PyPI form there would clobber the editable install), otherwise the PyPI
+    ``flextool[toolbox]`` form."""
+    if git_checkout_root() is not None:
+        return 'pip install -e ".[toolbox]"'
+    return 'pip install "flextool[toolbox]"'
+
+
 def upgrade_steps(include_toolbox: bool) -> tuple[list[list[str]], Path | None]:
     """Build the command(s) that upgrade FlexTool in place.
 

--- a/flextool/update_flextool/install_info.py
+++ b/flextool/update_flextool/install_info.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import importlib.metadata as _im
 import json
 import logging
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -58,12 +57,15 @@ def flextool_version() -> str:
 
 
 def toolbox_installed() -> bool:
-    """Whether Spine Toolbox (and thus the Spine DB Editor) is installed."""
+    """Whether Spine Toolbox is installed *in the current environment* (the venv
+    running FlexTool). Deliberately does NOT fall back to a PATH lookup — a
+    ``spine-db-editor`` from a different environment would otherwise read as
+    installed even though it isn't importable here."""
     try:
         _im.distribution("spinetoolbox")
         return True
     except _im.PackageNotFoundError:
-        return shutil.which("spine-db-editor") is not None
+        return False
 
 
 def describe_install() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flextool"
-version = "4.0.0"
+version = "4.0.1"
 description = "IRENA FlexTool is an energy and power systems model for understanding the role of variable power generation in future energy systems."
 readme = "README.md"
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
Patch release on top of 4.0.0. GUI-only — no schema or model changes.

## Fixes
- **Install Spine Toolbox from the GUI now works.** The install action was tied to the (disabled-when-up-to-date) Update button; it's now a dedicated **"Install Spine Toolbox"** button shown only when Toolbox is missing, installing just the extra.
- **Environment-scoped detection & launch.** `toolbox_installed()` no longer reports "installed" when a `spine-db-editor` from another environment is on PATH; it checks the current venv. The DB editor is launched via `python -m spinetoolbox.spine_db_editor.main` (current environment), matching the CLI.
- **Docs:** recommended install now includes the `[toolbox,viewer]` extras; plain `pip install flextool` documented as spreadsheet-only.

Cherry-picked from `release/4.0.0` (post-v4.0.0), plus the version bump + CHANGELOG.

After merge: tag `v4.0.1` → auto-publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KVkswECwzzNP8U13CgNBj